### PR TITLE
modify converting exception

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
         'pillow',
         'svgwrite',
         'numpy',
-        'psd-tools2>=1.6.1',
+        'psd-tools2>=1.6.3',
         'future',
     ],
     include_package_data=True,

--- a/src/psd2svg/converter/core.py
+++ b/src/psd2svg/converter/core.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import, unicode_literals
 from logging import getLogger
 import psd_tools
+from psd_tools.user_api.psd_image import _VisibleLayer
+
 from psd2svg.converter.constants import BLEND_MODE
 from psd2svg.utils.xml import safe_utf8
 
@@ -114,7 +116,7 @@ class LayerConverter(object):
             self._current_group = target
             self._add_group(layer.layers)
             self._current_group = current_group
-        elif layer.kind in ('pixel', 'type', 'shape') and (
+        elif isinstance(layer, _VisibleLayer) and (
             layer.bbox.width > 0 and layer.bbox.height > 0):
             # Regular pixel layer.
             target = self._dwg.image(

--- a/src/psd2svg/converter/core.py
+++ b/src/psd2svg/converter/core.py
@@ -145,7 +145,7 @@ class LayerConverter(object):
             anchors = [
                 (p['anchor'][1] * self.width,
                  p['anchor'][0] * self.height)
-                for p in vsms.path if p['selector'] in (1, 2)]
+                for p in vsms.path if p['selector'] in (1, 2, 4, 5)]
             fill = 'none'
             if b'SoCo' in blocks:
                 items = dict(blocks[b'SoCo'].data.items)

--- a/src/psd2svg/converter/core.py
+++ b/src/psd2svg/converter/core.py
@@ -150,10 +150,7 @@ class LayerConverter(object):
                 (p['anchor'][1] * self.width,
                  p['anchor'][0] * self.height)
                 for p in vsms.path if p['selector'] in (1, 2, 4, 5)]
-            fill = 'none'
-            if b'SoCo' in blocks:
-                items = dict(blocks[b'SoCo'].data.items)
-                fill = self._get_color_in_item(items)
+            fill = self._get_fill(layer)
             target = self._dwg.polygon(points=anchors, fill=fill)
             target.set_desc(title=safe_utf8(layer.name))
         else:

--- a/src/psd2svg/converter/core.py
+++ b/src/psd2svg/converter/core.py
@@ -16,6 +16,8 @@ class LayerConverter(object):
     def _add_group(self, layers):
         for layer in reversed(layers):
             self._add_layer(layer)
+            for clip in reversed(layer.clip_layers):
+                self._add_layer(clip)
 
     def _add_layer(self, layer):
         target = self._get_target(layer)

--- a/src/psd2svg/converter/core.py
+++ b/src/psd2svg/converter/core.py
@@ -2,6 +2,8 @@
 from __future__ import absolute_import, unicode_literals
 from logging import getLogger
 import psd_tools
+from psd_tools import BBox
+from psd_tools.constants import TaggedBlock
 from psd_tools.user_api.psd_image import _VisibleLayer
 
 from psd2svg.converter.constants import BLEND_MODE
@@ -152,6 +154,13 @@ class LayerConverter(object):
                 for p in vsms.path if p['selector'] in (1, 2, 4, 5)]
             fill = self._get_fill(layer)
             target = self._dwg.polygon(points=anchors, fill=fill)
+            target.set_desc(title=safe_utf8(layer.name))
+        elif any(TaggedBlock.is_fill_key(key) for key in layer._tagged_blocks.keys()):
+            record = layer._info
+            bbox = BBox(record.left, record.top, record.right, record.bottom)
+            target = self._dwg.rect(
+                insert=(bbox.x1, bbox.y1), size=(bbox.width, bbox.height),
+                fill=self._get_fill(layer))
             target.set_desc(title=safe_utf8(layer.name))
         else:
             target = self._get_adjustments(layer)

--- a/src/psd2svg/converter/effects.py
+++ b/src/psd2svg/converter/effects.py
@@ -3,6 +3,7 @@ from __future__ import absolute_import, unicode_literals
 from logging import getLogger
 import numpy as np
 import svgwrite
+from psd_tools.constants import TaggedBlock
 from psd_tools.decoder.actions import List, Descriptor
 from psd2svg.converter.constants import BLEND_MODE2
 from psd2svg.utils.color import cmyk2rgb
@@ -372,9 +373,13 @@ class EffectsConverter(object):
 
     def _get_fill(self, layer):
         blocks = layer._tagged_blocks
-        if b'SoCo' in blocks:
-            items = dict(blocks[b'SoCo'].data.items)
-            return self._get_color_in_item(items)
+        if b'PtFl' in blocks:  # TODO implement
+            logger.warning('Unsupported pattern fill')
+            return 'none'
+        for key in TaggedBlock._FILL_KEYS:
+            if key in blocks:
+                items = dict(blocks[key].data.items)
+                return self._get_color_in_item(items)
         return 'none'
 
     def _make_pattern(self, items, insert=(0, 0)):

--- a/src/psd2svg/converter/effects.py
+++ b/src/psd2svg/converter/effects.py
@@ -370,6 +370,13 @@ class EffectsConverter(object):
             logger.error('Unknown color in items: {}'.format(items.keys()))
             raise NotImplementedError
 
+    def _get_fill(self, layer):
+        blocks = layer._tagged_blocks
+        if b'SoCo' in blocks:
+            items = dict(blocks[b'SoCo'].data.items)
+            return self._get_color_in_item(items)
+        return 'none'
+
     def _make_pattern(self, items, insert=(0, 0)):
         pattern_id = dict(items[b'Ptrn'].items)[b'Idnt'].value
         patt = self._psd.patterns.get(pattern_id, None)

--- a/src/psd2svg/converter/shape.py
+++ b/src/psd2svg/converter/shape.py
@@ -27,7 +27,7 @@ class ShapeConverter(object):
 
     def _generate_path(self, vsms, command='C'):
         # Iterator for SVG path constructor.
-        anchors = [p for p in vsms.path if p['selector'] in (1, 2)]
+        anchors = [p for p in vsms.path if p['selector'] in (1, 2, 4, 5)]
 
         # Initial point.
         yield 'M'


### PR DESCRIPTION
Modified because there are some exceptions which were not raised in be16de5.
(I think converting behavior is almost nearly equivalent to be16de5 now)

According to psd-tools api change, some adjustment/fill layer is converted to `rect` in this PR.
(previously handled as image layer, `as_PIL()`)
