### PR TITLE
Fix crash for unknown blend mode

### DIFF
--- a/src/psd2svg/core/constants.py
+++ b/src/psd2svg/core/constants.py
@@ -35,29 +35,30 @@ BLEND_MODE: dict[Union[BlendMode, bytes], str] = {
     BlendMode.COLOR: "color",
     BlendMode.LUMINOSITY: "luminosity",
     # Descriptor values.
+    # TODO: Check bytes values.
     Enum.Normal: "normal",
     Enum.Dissolve: "normal",
     Enum.Darken: "darken",
     Enum.Multiply: "multiply",
     Enum.ColorBurn: "color-burn",
     b"linearBurn": "plus-darker",
-    # darker-color?
+    b"darkerColor": "darken",
     Enum.Lighten: "lighten",
     Enum.Screen: "screen",
     Enum.ColorDodge: "color-dodge",
     b"linearDodge": "plus-lighter",
-    # lighter-color?
+    b"lighterColor": "lighten",
     Enum.Overlay: "overlay",
     Enum.SoftLight: "soft-light",
     Enum.HardLight: "hard-light",
-    # vivid-light?
-    # linear-light?
-    # pin-light?
-    # hard-mix?
+    b'vividLight': "lighten",
+    b'linearLight': "darken",
+    b'pinLight': "normal",
+    b'hardMix': "normal",
     Enum.Difference: "difference",
     Enum.Exclusion: "exclusion",
     Enum.Subtract: "difference",
-    # divide?
+    b"divide": "difference",
     Enum.Hue: "hue",
     Enum.Saturation: "saturation",
     Enum.Color: "color",

--- a/src/psd2svg/core/layer.py
+++ b/src/psd2svg/core/layer.py
@@ -125,6 +125,9 @@ class LayerConverter(ConverterProtocol):
 
     def set_blend_mode(self, psd_mode: bytes | str, node: ET.Element) -> None:
         """Set blend mode style to the node."""
+        if psd_mode not in BLEND_MODE:
+            logger.warning(f"Unsupported blend mode: {psd_mode!r}")
+            return
         blend_mode = BLEND_MODE[psd_mode]
         if blend_mode not in ("normal", "pass-through"):
             svg_utils.add_style(node, "mix-blend-mode", blend_mode)


### PR DESCRIPTION
Changes:
- Add blend mode keys
- Add a warning instead of `KeyError` when there is an unknown key