### PR TITLE
Add warnings for inaccurate blend modes and error handling

### DIFF
--- a/src/psd2svg/core/constants.py
+++ b/src/psd2svg/core/constants.py
@@ -64,3 +64,36 @@ BLEND_MODE: dict[Union[BlendMode, bytes], str] = {
     Enum.Color: "color",
     Enum.Luminosity: "luminosity",
 }
+
+# Blend modes that are not accurately supported in SVG and are mapped to approximations.
+# These will trigger warnings when used.
+INACCURATE_BLEND_MODES: set[Union[BlendMode, bytes]] = {
+    # Dissolve mode uses random pixel patterns, not supported in SVG
+    BlendMode.DISSOLVE,
+    Enum.Dissolve,
+    # Linear burn uses plus-darker which has limited browser support
+    BlendMode.LINEAR_BURN,
+    b"linearBurn",
+    # Linear dodge uses plus-lighter which has limited browser support
+    BlendMode.LINEAR_DODGE,
+    b"linearDodge",
+    # Darker/Lighter Color modes compare color values, approximated with darken/lighten
+    BlendMode.DARKER_COLOR,
+    b"darkerColor",
+    BlendMode.LIGHTER_COLOR,
+    b"lighterColor",
+    # Advanced light modes approximated with simpler modes
+    BlendMode.VIVID_LIGHT,
+    b'vividLight',
+    BlendMode.LINEAR_LIGHT,
+    b'linearLight',
+    BlendMode.PIN_LIGHT,
+    b'pinLight',
+    BlendMode.HARD_MIX,
+    b'hardMix',
+    # Subtract and Divide modes approximated with difference
+    BlendMode.SUBTRACT,
+    Enum.Subtract,
+    BlendMode.DIVIDE,
+    b"divide",
+}

--- a/tests/test_blend_modes.py
+++ b/tests/test_blend_modes.py
@@ -1,0 +1,201 @@
+"""Tests for blend mode warning functionality."""
+
+import logging
+from unittest.mock import Mock
+from xml.etree import ElementTree as ET
+
+import pytest
+from psd_tools.constants import BlendMode
+from psd_tools.terminology import Enum
+
+from psd2svg.core.layer import LayerConverter
+
+
+class TestBlendModeWarnings:
+    """Test that warnings are emitted for inaccurate blend modes."""
+
+    @pytest.fixture
+    def converter(self):
+        """Create a minimal LayerConverter instance for testing."""
+        converter = Mock(spec=LayerConverter)
+        converter.set_blend_mode = LayerConverter.set_blend_mode.__get__(
+            converter, LayerConverter
+        )
+        return converter
+
+    @pytest.fixture
+    def node(self):
+        """Create a test XML element."""
+        return ET.Element("g")
+
+    def test_dissolve_blend_mode_warning(self, converter, node, caplog):
+        """Test that dissolve blend mode triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.DISSOLVE, node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "DISSOLVE" in caplog.text or "Dissolve" in caplog.text
+        assert "normal" in caplog.text
+
+    def test_linear_burn_blend_mode_warning(self, converter, node, caplog):
+        """Test that linear burn blend mode triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.LINEAR_BURN, node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "LINEAR_BURN" in caplog.text or "Linear" in caplog.text
+        assert "plus-darker" in caplog.text
+
+    def test_linear_dodge_blend_mode_warning(self, converter, node, caplog):
+        """Test that linear dodge blend mode triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.LINEAR_DODGE, node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "LINEAR_DODGE" in caplog.text or "Linear" in caplog.text
+        assert "plus-lighter" in caplog.text
+
+    def test_bytes_linear_burn_blend_mode_warning(self, converter, node, caplog):
+        """Test that bytes linearBurn also triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(b"linearBurn", node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "plus-darker" in caplog.text
+
+    def test_bytes_linear_dodge_blend_mode_warning(self, converter, node, caplog):
+        """Test that bytes linearDodge also triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(b"linearDodge", node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "plus-lighter" in caplog.text
+
+    def test_pin_light_blend_mode_warning(self, converter, node, caplog):
+        """Test that pin light blend mode triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.PIN_LIGHT, node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "normal" in caplog.text
+
+    def test_hard_mix_blend_mode_warning(self, converter, node, caplog):
+        """Test that hard mix blend mode triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.HARD_MIX, node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "normal" in caplog.text
+
+    def test_darker_color_blend_mode_warning(self, converter, node, caplog):
+        """Test that darker color blend mode triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.DARKER_COLOR, node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "darken" in caplog.text
+
+    def test_lighter_color_blend_mode_warning(self, converter, node, caplog):
+        """Test that lighter color blend mode triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.LIGHTER_COLOR, node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "lighten" in caplog.text
+
+    def test_vivid_light_blend_mode_warning(self, converter, node, caplog):
+        """Test that vivid light blend mode triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.VIVID_LIGHT, node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "lighten" in caplog.text
+
+    def test_linear_light_blend_mode_warning(self, converter, node, caplog):
+        """Test that linear light blend mode triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.LINEAR_LIGHT, node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "darken" in caplog.text
+
+    def test_subtract_blend_mode_warning(self, converter, node, caplog):
+        """Test that subtract blend mode triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.SUBTRACT, node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "difference" in caplog.text
+
+    def test_divide_blend_mode_warning(self, converter, node, caplog):
+        """Test that divide blend mode triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.DIVIDE, node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "difference" in caplog.text
+
+    def test_enum_dissolve_blend_mode_warning(self, converter, node, caplog):
+        """Test that Enum.Dissolve also triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(Enum.Dissolve, node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "normal" in caplog.text
+
+    def test_bytes_vivid_light_blend_mode_warning(self, converter, node, caplog):
+        """Test that bytes blend mode also triggers a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(b'vividLight', node)
+
+        assert len(caplog.records) == 1
+        assert "not accurately supported" in caplog.text
+        assert "lighten" in caplog.text
+
+    def test_accurate_blend_mode_no_warning(self, converter, node, caplog):
+        """Test that accurate blend modes don't trigger warnings."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.MULTIPLY, node)
+
+        # Should have no warnings
+        assert len(caplog.records) == 0
+
+    def test_normal_blend_mode_no_warning(self, converter, node, caplog):
+        """Test that normal blend mode doesn't trigger a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.NORMAL, node)
+
+        assert len(caplog.records) == 0
+
+    def test_screen_blend_mode_no_warning(self, converter, node, caplog):
+        """Test that screen blend mode doesn't trigger a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.SCREEN, node)
+
+        assert len(caplog.records) == 0
+
+    def test_overlay_blend_mode_no_warning(self, converter, node, caplog):
+        """Test that overlay blend mode doesn't trigger a warning."""
+        with caplog.at_level(logging.WARNING):
+            converter.set_blend_mode(BlendMode.OVERLAY, node)
+
+        assert len(caplog.records) == 0
+
+    def test_unsupported_blend_mode_raises_error(self, converter, node):
+        """Test that completely unsupported blend modes raise ValueError."""
+        with pytest.raises(ValueError, match="Unsupported blend mode"):
+            converter.set_blend_mode(b"unsupported_mode", node)


### PR DESCRIPTION
## Summary

This PR enhances blend mode handling by adding warning messages for blend modes that are not accurately supported in SVG, and improving error handling for invalid blend modes.

### Changes

- **Added `INACCURATE_BLEND_MODES` set** in `constants.py` containing 12 blend modes that have limited or no accurate SVG support
- **Enhanced `set_blend_mode()` method** in `layer.py` to:
  - Emit warnings when inaccurate blend modes are used, informing users what approximation is being applied
  - Raise `ValueError` for completely unsupported blend modes (breaking change)
  - Include comprehensive docstring with Args and Raises documentation
- **Added comprehensive test suite** with 20 test cases covering all scenarios

### Inaccurate Blend Modes with Warnings

The following blend modes now trigger warnings when used:

1. **DISSOLVE** → maps to `normal` (random pixel patterns not supported in SVG)
2. **LINEAR_BURN** → maps to `plus-darker` (limited browser support)
3. **LINEAR_DODGE** → maps to `plus-lighter` (limited browser support)
4. **DARKER_COLOR** → approximated with `darken`
5. **LIGHTER_COLOR** → approximated with `lighten`
6. **VIVID_LIGHT** → approximated with `lighten`
7. **LINEAR_LIGHT** → approximated with `darken`
8. **PIN_LIGHT** → approximated with `normal`
9. **HARD_MIX** → approximated with `normal`
10. **SUBTRACT** → approximated with `difference`
11. **DIVIDE** → approximated with `difference`

### Example Warning Output

```
WARNING: Blend mode 'DISSOLVE' is not accurately supported in SVG. Using approximation 'normal' instead.
WARNING: Blend mode 'LINEAR_BURN' is not accurately supported in SVG. Using approximation 'plus-darker' instead.
```

### Breaking Change

⚠️ **Breaking Change**: `set_blend_mode()` now raises `ValueError` for invalid blend modes instead of logging a warning and silently continuing. This provides better error handling and helps catch issues earlier in the conversion process.

### Test Results

- ✅ All 20 new blend mode tests pass
- ✅ All 79 existing conversion tests pass
- ✅ Linting passes (ruff)
- ✅ Type checking shows no new issues

## Test plan

- [x] Run `uv run pytest tests/test_blend_modes.py` - all tests pass
- [x] Run `uv run pytest tests/test_convert.py` - all existing tests pass
- [x] Run `uv run ruff check src/` - linting passes
- [x] Run `uv run mypy src/` - no new type errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)