### PR TITLE
Fix shape transform handling to correctly apply reference offset

### DIFF
--- a/src/psd2svg/core/shape.py
+++ b/src/psd2svg/core/shape.py
@@ -390,26 +390,25 @@ class ShapeConverter(ConverterProtocol):
             float(transform[b"tx"]),
             float(transform[b"ty"]),
         )
-        if matrix[:4] == (1, 0, 0, 1):
-            if matrix[4] - reference[0] == 0 and matrix[5] - reference[1] == 0:
-                # Identity matrix, no transform needed.
-                return
-            else:
-                # Simple translation
-                svg_utils.append_attribute(
-                    node,
-                    "transform",
-                    "translate(%s)" % svg_utils.seq2str(matrix[4:], digit=4),
-                )
-        else:
+        if (
+            matrix[:4] == (1, 0, 0, 1)
+            and matrix[4] - reference[0] == 0
+            and matrix[5] - reference[1] == 0
+        ):
+            # Identity matrix, no transform needed.
+            return
+
+        if matrix != (1, 0, 0, 1, 0, 0):
+            svg_utils.append_attribute(
+                node, "transform", "matrix(%s)" % svg_utils.seq2str(matrix, digit=4)
+            )
+
+        if reference != (0.0, 0.0):
             svg_utils.append_attribute(
                 node,
                 "transform",
-                "matrix(%s) translate(%s)"
-                % (
-                    svg_utils.seq2str(matrix, digit=4),
-                    svg_utils.seq2str((-reference[0], -reference[1]), digit=4),
-                ),
+                "translate(%s)"
+                % svg_utils.seq2str((-reference[0], -reference[1]), digit=4),
             )
 
     def create_path(self, path: Subpath, **attrib) -> ET.Element:


### PR DESCRIPTION
## Summary
- Fixes incorrect transform handling when translation-only transforms occur with non-zero reference offsets
- Refactors transform logic to handle identity, matrix-only, translation-only, and combined cases correctly

## Changes
The previous implementation had a bug where reference offsets were ignored in translation-only cases. The fix:
- Only skips transform application when truly identity (matrix is identity AND translation matches reference offset)
- Separately applies matrix transform when non-identity  
- Separately applies reference offset translation when non-zero

## Test plan
- [x] All 179 tests pass (4 expected xfails)
- [x] Type checking passes (no new errors introduced)
- [x] Linting and formatting checks pass
- [x] Verified transform logic handles all cases correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)