### PR TITLE
Add ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version, and other tools you might need
+build:
+  os: ubuntu-24.04
+  tools:
+    python: "3.13"
+  jobs:
+    post_install:
+      - pip install uv
+      - uv sync --group docs
+
+# Build documentation in the "docs/" directory with Sphinx
+sphinx:
+   configuration: docs/conf.py


### PR DESCRIPTION
## Summary
- Add `.readthedocs.yaml` configuration file for automated documentation builds
- Configure to use Python 3.13 on Ubuntu 24.04
- Set up `uv` for dependency management to install docs dependencies from `pyproject.toml`

## Test plan
- [x] Verify the configuration syntax is valid
- [x] Connect the repository to ReadTheDocs
- [ ] Test that documentation builds successfully on ReadTheDocs

🤖 Generated with [Claude Code](https://claude.com/claude-code)