### PR TITLE
Fix ReadTheDocs build: Install all dependency groups

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,7 +12,7 @@ build:
   jobs:
     post_install:
       - pip install uv
-      - uv sync --group docs
+      - uv sync --all-groups
 
 # Build documentation in the "docs/" directory with Sphinx
 sphinx:


### PR DESCRIPTION
## Summary
- Fix ReadTheDocs build failure caused by missing package dependencies
- Change `uv sync --group docs` to `uv sync --all-groups` in `.readthedocs.yaml`

## Problem
The ReadTheDocs build was failing with error: `Sphinx failed to import 'sphinx_autodoc_typehints' extension`

While the extension itself was installed, Sphinx's autodoc feature needs to import the `psd2svg` package to generate documentation. This requires the main package dependencies (pillow, numpy, psd-tools, resvg-py) to be installed as well.

## Solution
Install all dependency groups including:
- Main package dependencies (required for autodoc to import psd2svg)
- Docs dependencies (sphinx, sphinx-rtd-theme, sphinx-autodoc-typehints, myst-parser)

## Test plan
- [ ] Verify ReadTheDocs build completes successfully
- [ ] Check that documentation is generated correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)