### PR TITLE
Fix release workflow permissions for GitHub release creation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,6 +14,7 @@ jobs:
       url: https://pypi.org/p/psd2svg
     permissions:
       id-token: write
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
## Summary
- Add `contents: write` permission to the release workflow to allow GitHub release creation
- Fixes the 403 error encountered when the workflow tried to create a release for tag `v0.3.0a1`

## Test plan
- [x] Merge this PR
- [ ] Re-run the failed release workflow or create a new tag to verify the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)