### PR TITLE
Fix pattern transform angle handling when key is missing

### DIFF
--- a/src/psd2svg/core/effects.py
+++ b/src/psd2svg/core/effects.py
@@ -750,12 +750,12 @@ class EffectConverter(ConverterProtocol):
                 "patternTransform",
                 f"scale({svg_utils.num2str(scale / 100.0)})",
             )
-        if effect.angle != 0.0:
-            rotation = -effect.angle
+        angle = -float(effect.value.get(Key.Angle, UnitFloat(Unit.Angle, 0.0)).value)
+        if angle != 0.0:
             svg_utils.append_attribute(
                 pattern,
                 "patternTransform",
-                f"rotate({svg_utils.num2str(rotation)})",
+                f"rotate({svg_utils.num2str(angle)})",
             )
 
     def apply_inner_shadow_effect(


### PR DESCRIPTION
## Summary

- Fixes a bug where accessing `effect.angle` raises an exception when the underlying data doesn't have the 'angle' key in psd_tools
- Changes to use `effect.value.get(Key.Angle, UnitFloat(Unit.Angle, 0.0))` with a default value
- Follows the same pattern already used for the `Scale` key handling

## Test plan

- [ ] Verify the fix prevents exceptions when processing pattern overlays without angle data
- [ ] Confirm pattern transforms still work correctly when angle data is present
- [ ] Run existing test suite: `uv run pytest`
- [ ] Run type checking: `uv run mypy src/`
- [ ] Run linting: `uv run ruff check src/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)