### PR TITLE
Add enable_live_shapes flag to control shape layer conversion

### DIFF
--- a/src/psd2svg/core/base.py
+++ b/src/psd2svg/core/base.py
@@ -16,6 +16,9 @@ class ConverterProtocol(Protocol):
     current: ET.Element
     images: list[Image.Image]
 
+    # Flags to control the conversion.
+    enable_live_shapes: bool
+
     def add_layer(self, layer: layers.Layer, **attrib: str) -> ET.Element | None: ...
     def add_group(self, layer: layers.Group, **attrib: str) -> ET.Element | None: ...
     def add_pixel(self, layer: layers.Layer, **attrib: str) -> ET.Element | None: ...
@@ -40,7 +43,7 @@ class ConverterProtocol(Protocol):
 
     # Shape methods
     def create_shape(self, layer: layers.ShapeLayer, **attrib) -> ET.Element: ...
-    
+
     # Paint methods
     def apply_vector_fill(
         self, layer: layers.ShapeLayer | adjustments.FillLayer, target: ET.Element

--- a/src/psd2svg/core/converter.py
+++ b/src/psd2svg/core/converter.py
@@ -45,17 +45,21 @@ class Converter(
         document.embed_images()  # or document.export_images("output/image_%02d")
         svg_string = document.export()
 
+    Args:
+        psdimage: Source PSDImage to convert.
+        enable_live_shapes: Enable live shape conversion when possible.
     """
 
     _id_counter: AutoCounter | None = None
 
-    def __init__(self, psdimage: PSDImage) -> None:
+    def __init__(self, psdimage: PSDImage, enable_live_shapes: bool = True) -> None:
         """Initialize the converter internal state."""
 
         # Source PSD image.
         if not isinstance(psdimage, PSDImage):
             raise TypeError("psdimage must be an instance of PSDImage")
         self.psd = psdimage
+        self.enable_live_shapes = enable_live_shapes
 
         # Initialize the SVG root element.
         self.svg = svg_utils.create_node(

--- a/src/psd2svg/core/layer.py
+++ b/src/psd2svg/core/layer.py
@@ -173,9 +173,12 @@ class LayerConverter(ConverterProtocol):
 
     def add_shape(self, layer: layers.ShapeLayer, **attrib: str) -> ET.Element | None:
         """Add a shape layer to the svg document."""
-        if layer.has_effects() or (
-            # layer.origination is not None
-            # and any(b"Trnf" in o._data for o in layer.origination)
+        if (
+            layer.has_effects()
+            or (
+                # layer.origination is not None
+                # and any(b"Trnf" in o._data for o in layer.origination)
+            )
         ):
             # We need to split the shape definition and effects.
             defs = svg_utils.create_node("defs", parent=self.current)
@@ -520,6 +523,6 @@ class LayerConverter(ConverterProtocol):
             )
             svg_utils.set_attribute(use, "id", self.auto_id("use"))
             return use
-        
+
         svg_utils.set_attribute(target, "mask", svg_utils.get_funciri(mask))
         return target

--- a/src/psd2svg/core/paint.py
+++ b/src/psd2svg/core/paint.py
@@ -15,6 +15,7 @@ This module handles paint application for:
 Note layer effects also support similar paint types, but the data
 structures and descriptors are different.
 """
+
 import logging
 import xml.etree.ElementTree as ET
 

--- a/src/psd2svg/core/shape.py
+++ b/src/psd2svg/core/shape.py
@@ -11,6 +11,7 @@ Handles conversion of Photoshop vector shapes to SVG path elements:
 The module processes vector mask data from shape layers and converts
 Photoshop's knot points and control points to SVG path syntax.
 """
+
 import logging
 import xml.etree.ElementTree as ET
 from typing import Iterator, Literal
@@ -264,7 +265,7 @@ class ShapeConverter(ConverterProtocol):
         if layer.vector_mask.initial_fill_rule:
             logger.warning("Initial fill rule (inverted mask) is not supported yet.")
 
-        if layer.has_origination():
+        if self.enable_live_shapes and layer.has_origination():
             origination = layer.origination[path.index]
             reference = layer.tagged_blocks.get_data(Tag.REFERENCE_POINT, (0.0, 0.0))
             if isinstance(origination, Rectangle):

--- a/src/psd2svg/svg_document.py
+++ b/src/psd2svg/svg_document.py
@@ -20,7 +20,7 @@ DEFAULT_IMAGE_FORMAT = "webp"
 class SVGDocument:
     """SVG document and resources.
 
-    Example usage:
+    Example usage::
 
         from psd_tools import PSDImage
         from psd2svg import SVGDocument
@@ -46,13 +46,19 @@ class SVGDocument:
     # TODO: Font handling.
 
     @staticmethod
-    def from_psd(psdimage: PSDImage) -> "SVGDocument":
+    def from_psd(psdimage: PSDImage, enable_live_shapes: bool = True) -> "SVGDocument":
         """Create a new SVGDocument from a PSDImage.
 
         Args:
             psdimage: PSDImage object to convert.
+            enable_live_shapes: Enable live shape conversion when possible.
+                Disabling live shapes results in <path> elements instead of
+                shape primitives like <rect> or <circle>. This may be more
+                accurate, but less editable.
+        Returns:
+            SVGDocument object containing the converted SVG and images.
         """
-        converter = Converter(psdimage)
+        converter = Converter(psdimage, enable_live_shapes=enable_live_shapes)
         converter.build()
         return SVGDocument(svg=converter.svg, images=converter.images)
 

--- a/src/psd2svg/svg_utils.py
+++ b/src/psd2svg/svg_utils.py
@@ -159,8 +159,8 @@ def wrap_element(
     node: ET.Element, parent: ET.Element, wrapper: ET.Element
 ) -> ET.Element:
     """Wrap the given existing node in the wrapper element.
-    
-    Usage:
+
+    Usage::
         wrapper = svg_utils.create_node("g")
         wrapped_node = svg_utils.wrap_element(node, parent, wrapper)
 

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -5,6 +5,7 @@ import pytest
 from psd_tools import PSDImage
 
 from psd2svg import convert
+from psd2svg.core.converter import Converter
 from psd2svg.eval import compute_conversion_quality
 
 from .conftest import get_fixture
@@ -243,6 +244,21 @@ def test_blend_mode_quality(psd_file: str, quality: float) -> None:
 def test_shapes(psd_file: str) -> None:
     """Test conversion quality of shape layers."""
     evaluate_quality(psd_file, 0.02)
+
+
+def test_enable_live_shapes_flag() -> None:
+    """Test that disabling live shapes works."""
+    psdimage = PSDImage.open(get_fixture("shapes/rectangle-1.psd"))
+
+    converter = Converter(psdimage, enable_live_shapes=True)
+    converter.build()
+    assert converter.svg.find(".//rect") is not None, "Expected <rect> element in SVG with live shapes enabled."
+    assert converter.svg.find(".//path") is None, "Did not expect <path> element in SVG with live shapes enabled."
+
+    converter = Converter(psdimage, enable_live_shapes=False)
+    converter.build()
+    assert converter.svg.find(".//rect") is None, "Did not expect <rect> element in SVG with live shapes disabled."
+    assert converter.svg.find(".//path") is not None, "Expected <path> element in SVG with live shapes disabled."
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- Add `enable_live_shapes` parameter to `SVGDocument.from_psd()` to control shape layer conversion behavior
- When enabled (default), uses SVG primitives like `<rect>`, `<circle>` for editable shapes
- When disabled, converts all shapes to `<path>` elements for maximum accuracy
- Add comprehensive test coverage for both modes
- Fix code formatting issues throughout modified files

## Motivation

Users need control over the trade-off between editability and rendering accuracy when converting PSD shape layers. Live shapes are more editable in SVG editors but may have slight differences, while path-based conversion is more accurate but less editable.

## Changes

**API Changes:**
- Add `enable_live_shapes: bool = True` parameter to `SVGDocument.from_psd()` and `Converter.__init__()`
- Add protocol field to `ConverterProtocol` for type safety

**Implementation:**
- Guard origination-based shape conversion logic in [src/psd2svg/core/shape.py:268](src/psd2svg/core/shape.py#L268)
- When flag is disabled, all shapes use generic path conversion

**Testing:**
- Add `test_enable_live_shapes_flag()` verifying both enabled and disabled states
- Verify correct element types (`<rect>` vs `<path>`) based on flag value

**Code Quality:**
- Fix trailing whitespace and blank line formatting issues
- Improve RST docstring formatting

## Test Plan

- [x] Unit test verifies flag behavior with rectangle shape
- [x] Existing shape tests pass with default `enable_live_shapes=True`
- [x] Type checking passes with new protocol field
- [x] Code formatting checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)