### PR TITLE
Fix UnitFloat constructor to use keyword arguments

### DIFF
--- a/src/psd2svg/core/effects.py
+++ b/src/psd2svg/core/effects.py
@@ -602,7 +602,9 @@ class EffectConverter(ConverterProtocol):
         if angle != 0:
             transforms.append(f"rotate({svg_utils.num2str(angle)})")
 
-        scale = float(effect.value.get(Key.Scale, UnitFloat(Unit.Percent, 100.0)).value)
+        scale = float(
+            effect.value.get(Key.Scale, UnitFloat(unit=Unit.Percent, value=100.0)).value
+        )
         if scale != 100:
             if landscape:
                 transforms.append(
@@ -753,14 +755,18 @@ class EffectConverter(ConverterProtocol):
                     "patternTransform",
                     f"translate({svg_utils.seq2str(offset)})",
                 )
-        scale = float(effect.value.get(Key.Scale, UnitFloat(Unit.Percent, 100.0)).value)
+        scale = float(
+            effect.value.get(Key.Scale, UnitFloat(unit=Unit.Percent, value=100.0)).value
+        )
         if scale != 100.0:
             svg_utils.append_attribute(
                 pattern,
                 "patternTransform",
                 f"scale({svg_utils.num2str(scale / 100.0)})",
             )
-        angle = -float(effect.value.get(Key.Angle, UnitFloat(Unit.Angle, 0.0)).value)
+        angle = -float(
+            effect.value.get(Key.Angle, UnitFloat(unit=Unit.Angle, value=0.0)).value
+        )
         if angle != 0.0:
             svg_utils.append_attribute(
                 pattern,

--- a/src/psd2svg/core/paint.py
+++ b/src/psd2svg/core/paint.py
@@ -296,7 +296,9 @@ class PaintConverter(ConverterProtocol):
             )
 
         # Apply angle, scale, and offset transforms.
-        angle = -float(setting.get(Key.Angle, UnitFloat(0)).value)
+        angle = -float(
+            setting.get(Key.Angle, UnitFloat(unit=Unit.Angle, value=0.0)).value
+        )
         if landscape:
             angle -= 90
         if Key.Reverse in setting and setting[Key.Reverse].value:
@@ -304,7 +306,9 @@ class PaintConverter(ConverterProtocol):
         if angle != 0:
             transforms.append(f"rotate({svg_utils.num2str(angle)})")
 
-        scale = float(setting.get(Key.Scale, UnitFloat(100)).value)
+        scale = float(
+            setting.get(Key.Scale, UnitFloat(unit=Unit.Percent, value=100.0)).value
+        )
         if scale != 100:
             if landscape:
                 transforms.append(
@@ -383,7 +387,7 @@ class PaintConverter(ConverterProtocol):
         3. Rotation
         """
         # Reference point
-        reference = layer.tagged_blocks.get_data(Tag.REFERENCE_POINT, (0.0, 0.0))
+        reference = tuple(layer.tagged_blocks.get_data(Tag.REFERENCE_POINT, (0.0, 0.0)))
         if reference != (0.0, 0.0):
             svg_utils.append_attribute(
                 pattern,
@@ -405,7 +409,9 @@ class PaintConverter(ConverterProtocol):
         if scale != 1.0:
             transforms.append(f"scale({svg_utils.num2str(scale, digit=4)})")
 
-        angle = -float(setting.get(Key.Angle, UnitFloat(0.0)).value)
+        angle = -float(
+            setting.get(Key.Angle, UnitFloat(unit=Unit.Angle, value=0.0)).value
+        )
         if angle != 0.0:
             transforms.append(f"rotate({svg_utils.num2str(angle, digit=4)})")
 

--- a/tests/test_paint.py
+++ b/tests/test_paint.py
@@ -1,0 +1,84 @@
+"""Tests for paint functionality."""
+
+from unittest.mock import Mock
+from xml.etree import ElementTree as ET
+
+import pytest
+from psd_tools.api.layers import Layer
+from psd_tools.constants import Tag
+from psd_tools.psd import descriptor
+from psd_tools.psd.tagged_blocks import ListElement, TaggedBlocks
+from psd_tools.terminology import Key, Unit
+
+from psd2svg.core.paint import PaintConverter
+
+
+class TestPatternTransform:
+    """Test pattern transform handling."""
+
+    @pytest.fixture
+    def converter(self):
+        """Create a minimal PaintConverter instance for testing."""
+        converter = Mock(spec=PaintConverter)
+        converter.set_pattern_transform = PaintConverter.set_pattern_transform.__get__(
+            converter, PaintConverter
+        )
+        return converter
+
+    @pytest.fixture
+    def layer(self):
+        """Create a mock layer."""
+        layer = Mock(spec=Layer)
+        layer.tagged_blocks = TaggedBlocks()
+        layer.tagged_blocks.set_data(Tag.REFERENCE_POINT, ListElement([0, 0]))
+        return layer
+
+    @pytest.fixture
+    def offset_layer(self):
+        """Create a mock layer."""
+        layer = Mock(spec=Layer)
+        layer.tagged_blocks = TaggedBlocks()
+        layer.tagged_blocks.set_data(Tag.REFERENCE_POINT, ListElement([0, 12]))
+        return layer
+
+    @pytest.fixture
+    def node(self):
+        """Create a test XML element."""
+        return ET.Element("pattern")
+
+    @pytest.fixture
+    def empty_setting(self):
+        """Create a mock empty descriptor setting."""
+        desc = descriptor.Descriptor()
+        return desc
+
+    @pytest.fixture
+    def angle_scale_setting(self):
+        """Create a mock empty descriptor setting."""
+        desc = descriptor.Descriptor()
+        desc[Key.Angle] = descriptor.UnitFloat(unit=Unit.Angle, value=45.0)
+        desc[Key.Scale] = descriptor.UnitFloat(unit=Unit.Percent, value=50.0)
+        return desc
+
+    def test_pattern_transform_empty(self, converter, layer, node, empty_setting):
+        """Test that setting an empty descriptor does not have pattern transform."""
+        converter.set_pattern_transform(layer, empty_setting, node)
+        assert "patternTransform" not in node.attrib
+
+    def test_pattern_transform_angle_scale(
+        self, converter, layer, node, angle_scale_setting
+    ):
+        """Test that setting angle and scale updates pattern transform."""
+        converter.set_pattern_transform(layer, angle_scale_setting, node)
+        assert "patternTransform" in node.attrib
+        assert node.attrib["patternTransform"] == "scale(0.5) rotate(-45)"
+
+    def test_pattern_transform_with_offset(
+        self, converter, offset_layer, node, angle_scale_setting
+    ):
+        """Test that setting angle and scale with offset updates pattern transform."""
+        converter.set_pattern_transform(offset_layer, angle_scale_setting, node)
+        assert "patternTransform" in node.attrib
+        assert (
+            node.attrib["patternTransform"] == "translate(0,12) scale(0.5) rotate(-45)"
+        )


### PR DESCRIPTION
## Summary

- Fix UnitFloat constructor calls to use explicit keyword arguments instead of positional arguments
- Add missing unit types in paint.py where numeric values were passed without units
- Add tuple() wrapper for reference point to ensure type safety
- Add comprehensive test coverage for pattern transform functionality

## Details

The `UnitFloat` constructor was being called with positional arguments throughout the codebase, which could lead to incorrect value assignments if the constructor signature changes or parameters are reordered. This PR fixes all instances to use explicit keyword arguments (`unit=` and `value=`).

### Changes in effects.py
- Line 605: `UnitFloat(Unit.Percent, 100.0)` → `UnitFloat(unit=Unit.Percent, value=100.0)`
- Line 758: `UnitFloat(Unit.Percent, 100.0)` → `UnitFloat(unit=Unit.Percent, value=100.0)`
- Line 768: `UnitFloat(Unit.Angle, 0.0)` → `UnitFloat(unit=Unit.Angle, value=0.0)`

### Changes in paint.py
- Line 299: `UnitFloat(0)` → `UnitFloat(unit=Unit.Angle, value=0.0)` (also adds missing unit type)
- Line 309: `UnitFloat(100)` → `UnitFloat(unit=Unit.Percent, value=100.0)` (also adds missing unit type)
- Line 390: Added `tuple()` wrapper for reference point
- Line 412: `UnitFloat(0.0)` → `UnitFloat(unit=Unit.Angle, value=0.0)` (also adds missing unit type)

### Test Coverage
Added `tests/test_paint.py` with three test cases:
- Empty descriptor → no transform
- Angle + scale with zero reference point
- Angle + scale with non-zero reference point (translation)

## Test plan

- [x] All existing tests pass
- [x] New tests verify pattern transform behavior
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)

🤖 Generated with [Claude Code](https://claude.com/claude-code)