### PR TITLE
Rename psd2svg.core.type to psd2svg.core.text for clarity

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,7 +73,7 @@ The package follows a modular converter architecture with multiple inheritance:
   - `LayerConverter` - Core layer conversion logic
   - `PaintConverter` - Handles painting logic
   - `ShapeConverter` - Converts vector shapes
-  - `TypeConverter` - Processes typographic layers
+  - `TextConverter` - Processes text layers
 
 ### Key Components
 

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -146,7 +146,7 @@ The core converter uses multiple inheritance with specialized mixins:
        LayerConverter,
        PaintConverter,
        ShapeConverter,
-       TypeConverter,
+       TextConverter,
    ):
        """Main converter class combining all converter mixins."""
 
@@ -157,7 +157,7 @@ The core converter uses multiple inheritance with specialized mixins:
 * ``LayerConverter`` (``layer.py``) - Core layer conversion logic
 * ``ShapeConverter`` (``shape.py``) - Converts vector shapes
 * ``PaintConverter`` (``paint.py``) - Handles painting logic
-* ``TypeConverter`` (``type.py``) - Processes typographic layers
+* ``TextConverter`` (``text.py``) - Processes text layers
 * ``PaintConverter`` (``paint.py``) - Handles fill and stroke patterns
 
 **Supporting Modules:**

--- a/src/psd2svg/core/converter.py
+++ b/src/psd2svg/core/converter.py
@@ -13,7 +13,7 @@ from psd2svg.core.effects import EffectConverter
 from psd2svg.core.layer import LayerConverter
 from psd2svg.core.paint import PaintConverter
 from psd2svg.core.shape import ShapeConverter
-from psd2svg.core.type import TypeConverter
+from psd2svg.core.text import TextConverter
 
 logger = logging.getLogger(__name__)
 
@@ -23,7 +23,7 @@ class Converter(
     LayerConverter,
     PaintConverter,
     ShapeConverter,
-    TypeConverter,
+    TextConverter,
     EffectConverter,
 ):
     """Converter main class.

--- a/src/psd2svg/core/text.py
+++ b/src/psd2svg/core/text.py
@@ -63,8 +63,8 @@ class FontBaseline(IntEnum):
     SUBSCRIPT = 2
 
 
-class TypeConverter(ConverterProtocol):
-    """Mixin for type layers."""
+class TextConverter(ConverterProtocol):
+    """Mixin for text layers."""
 
     def add_type(self, layer: layers.TypeLayer, **attrib: str) -> ET.Element | None:
         """Add a type layer to the svg document."""


### PR DESCRIPTION
## Summary

Renamed the `type` module to `text` to avoid confusion with Python's typing system. This change improves code clarity by explicitly indicating that the module handles text/typography conversion rather than type annotations.

## Changes

- Renamed `src/psd2svg/core/type.py` → `src/psd2svg/core/text.py`
- Renamed `TypeConverter` class → `TextConverter` class
- Updated all imports and references in `converter.py`
- Updated documentation in `CLAUDE.md` and `docs/development.rst`

## Test Plan

- [x] All 273 tests pass (1 skipped, 15 xfailed - same as before)
- [x] Type checking passes (`mypy src/`)
- [x] Linting passes (`ruff check src/`)
- [x] No functionality changes - pure refactor

🤖 Generated with [Claude Code](https://claude.com/claude-code)