### PR TITLE
Align CLI option with convert() function parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,19 +28,19 @@ psd2svg input.psd output/  # => output/input.svg
 psd2svg input.psd          # => input.svg
 ```
 
-When `--images-path` flag is specified, all png resources are exported to the path specified by `--images-path`:
+When `--image-prefix` flag is specified, all png resources are exported to the path specified by `--image-prefix`:
 
 ```bash
-psd2svg input.psd output.svg --images-path .
+psd2svg input.psd output.svg --image-prefix .
 # => output.svg, xxx1.png, ...
 
-psd2svg input.psd output/ --images-path .
+psd2svg input.psd output/ --image-prefix .
 # => output/input.svg, output/xxx1.png, ...
 
-psd2svg input.psd output/ --images-path=resources/
+psd2svg input.psd output/ --image-prefix=resources/
 # => output/input.svg, output/resources/xxx1.png, ...
 
-psd2svg input.psd svg/ --images-path=../png/
+psd2svg input.psd svg/ --image-prefix=../png/
 # => svg/input.svg, png/xxx1.png, ...
 ```
 

--- a/docs/getting-started.rst
+++ b/docs/getting-started.rst
@@ -53,20 +53,20 @@ When the output path is a directory or omitted, the tool infers the output name 
 External Image Resources
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
-Use the ``--images-path`` flag to export PNG resources to external files:
+Use the ``--image-prefix`` flag to export PNG resources to external files:
 
 .. code-block:: bash
 
    # Export images to current directory
-   psd2svg input.psd output.svg --images-path .
+   psd2svg input.psd output.svg --image-prefix .
    # => output.svg, xxx1.png, xxx2.png, ...
 
    # Export images to specific directory
-   psd2svg input.psd output/ --images-path resources/
+   psd2svg input.psd output/ --image-prefix resources/
    # => output/input.svg, output/resources/xxx1.png, ...
 
    # Export images to parent directory
-   psd2svg input.psd svg/ --images-path=../png/
+   psd2svg input.psd svg/ --image-prefix=../png/
    # => svg/input.svg, png/xxx1.png, ...
 
 Python API - Quick Start

--- a/src/psd2svg/__main__.py
+++ b/src/psd2svg/__main__.py
@@ -19,11 +19,11 @@ def parse_args() -> argparse.Namespace:
         help="Output file.",
     )
     parser.add_argument(
-        "--images-path",
+        "--image-prefix",
         metavar="PATH",
         type=str,
         default=None,
-        help="Path to images directory relative to output.",
+        help="Path prefix for saving extracted images relative to output.",
     )
     parser.add_argument(
         "--loglevel",
@@ -38,7 +38,7 @@ def main() -> None:
     """Main function to convert PSD to SVG or raster image."""
     args = parse_args()
     logging.basicConfig(level=getattr(logging, args.loglevel.upper(), "WARNING"))
-    convert(args.input, args.output, args.images_path)
+    convert(args.input, args.output, args.image_prefix)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

This PR aligns the CLI option naming with the `convert()` function parameter by changing `--images-path` to `--image-prefix`.

## Changes

- Updated CLI argument from `--images-path` to `--image-prefix` in [src/psd2svg/__main__.py](src/psd2svg/__main__.py)
- Improved help text to clarify it's a "path prefix" rather than just a "path"
- Updated all CLI examples in [README.md](README.md)
- Updated all CLI examples in [docs/getting-started.rst](docs/getting-started.rst)

## Motivation

The CLI was using `--images-path` while the underlying `convert()` function uses the parameter name `image_prefix`. This inconsistency was confusing. Since the package is in alpha status, this change removes the naming mismatch without needing a deprecation period.

## Testing

- ✅ All 179 tests pass (15 xfailed as expected)
- ✅ Type checking passes (mypy)
- ✅ Linting passes (ruff)
- ✅ CLI help displays correctly with the new option name

## Breaking Change

This is a breaking change for CLI users, but since the package is in alpha, no deprecation notice is needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)