### PR TITLE
Fix Export and Load documentation section

### DIFF
--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -83,10 +83,18 @@ Export the document to a dictionary format:
 
    # Export
    exported = document.export()
-   # Returns: {"svg": "<svg>...</svg>", "images": {"id1": <PIL.Image>, ...}}
+   # Returns: {
+   #     "svg": "<svg>...</svg>",
+   #     "images": [<bytes>, <bytes>, ...],
+   #     "fonts": [{"family": "Arial", "style": "normal", ...}, ...]
+   # }
 
    # Load back
-   document = SVGDocument.load(exported["svg"], exported["images"])
+   document = SVGDocument.load(
+       exported["svg"],
+       exported["images"],
+       exported["fonts"]
+   )
 
 This is useful for serialization or transferring documents between processes.
 


### PR DESCRIPTION
## Summary
- Fixed `images` format in export() return value (was incorrectly shown as dict, should be list[bytes])
- Added missing `fonts` parameter documentation
- Updated load() example to include the fonts argument

## Details
The "Export and Load" section in the user guide had two issues:
1. The `images` field was incorrectly documented as a dict like `{"id1": <PIL.Image>, ...}` when it's actually a list of bytes `[<bytes>, <bytes>, ...]`
2. The `fonts` parameter was missing entirely from the documentation, even though it's part of the export/load API

This PR corrects both issues to match the actual API implementation in `svg_document.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)