### PR TITLE
Refactor image handling from list-based to ID-based mapping

### DIFF
--- a/src/psd2svg/core/base.py
+++ b/src/psd2svg/core/base.py
@@ -18,7 +18,7 @@ class ConverterProtocol(Protocol):
     psd: PSDImage
     svg: ET.Element
     current: ET.Element
-    images: list[Image.Image]
+    images: dict[str, Image.Image]
     fonts: dict[str, "FontInfo"]
 
     # Flags to control the conversion.

--- a/src/psd2svg/core/converter.py
+++ b/src/psd2svg/core/converter.py
@@ -95,7 +95,7 @@ class Converter(
             height=psdimage.height,
             viewBox=svg_utils.seq2str([0, 0, psdimage.width, psdimage.height], sep=" "),
         )
-        self.images: list[Image.Image] = []  # Store PIL images here.
+        self.images: dict[str, Image.Image] = {}  # Store PIL images keyed by image ID.
         self.fonts: dict[
             str, FontInfo
         ] = {}  # Store font info keyed by postscript name.
@@ -109,12 +109,14 @@ class Converter(
 
         if len(self.psd) == 0 and self.psd.has_preview():
             # Special case: No layers, just a flat image.
+            image_id = self.auto_id("image")
             self.create_node(
                 "image",
+                id=image_id,
                 width=self.psd.width,
                 height=self.psd.height,
             )
-            self.images.append(self.psd.composite())
+            self.images[image_id] = self.psd.composite()
         else:
             self.add_children(self.psd)
 

--- a/src/psd2svg/core/layer.py
+++ b/src/psd2svg/core/layer.py
@@ -131,7 +131,10 @@ class LayerConverter(ConverterProtocol):
                 f"Layer has no image data, skipping: '{layer.name}' ({layer.kind})."
             )
             return None
-        self.images.append(image.convert("RGBA"))
+
+        # Generate image ID before creating the <image> element
+        image_id = self.auto_id("image")
+        self.images[image_id] = image.convert("RGBA")
 
         # Raster layers can have both fill opacity and overall opacity.
         fill_opacity = layer.tagged_blocks.get_data(Tag.BLEND_FILL_OPACITY, 255)
@@ -147,7 +150,7 @@ class LayerConverter(ConverterProtocol):
                 width=layer.width,
                 height=layer.height,
                 title=layer.name,
-                id=self.auto_id("image"),
+                id=image_id,
                 class_=layer.kind,
                 **attrib,
             )
@@ -161,6 +164,7 @@ class LayerConverter(ConverterProtocol):
         else:
             node = self.create_node(
                 "image",
+                id=image_id,
                 x=layer.left,
                 y=layer.top,
                 width=layer.width,
@@ -542,10 +546,12 @@ class LayerConverter(ConverterProtocol):
         # Mask image.
         mask_image = layer.mask.topil()
         if mask_image is not None:
-            self.images.append(mask_image.convert("L"))
+            image_id = self.auto_id("image")
+            self.images[image_id] = mask_image.convert("L")
             svg_utils.create_node(
                 "image",
                 parent=mask,
+                id=image_id,
                 x=layer.mask.left,
                 y=layer.mask.top,
                 width=layer.mask.width,

--- a/src/psd2svg/core/paint.py
+++ b/src/psd2svg/core/paint.py
@@ -365,6 +365,7 @@ class PaintConverter(ConverterProtocol):
         if pattern_data is None:
             raise ValueError(f"Pattern data not found: {pattern_id}")
         image = pil_io.convert_pattern_to_pil(pattern_data)
+        image_id = self.auto_id("image")
 
         node = self.create_node(
             "pattern",
@@ -374,10 +375,14 @@ class PaintConverter(ConverterProtocol):
             patternUnits="userSpaceOnUse",
         )
         svg_utils.create_node(
-            "image", parent=node, width=image.width, height=image.height
+            "image",
+            parent=node,
+            id=image_id,
+            width=image.width,
+            height=image.height,
         )
         # We will later fill in the href attribute when embedding images.
-        self.images.append(image)
+        self.images[image_id] = image
         return node
 
     def set_pattern_transform(

--- a/tests/test_font_collection.py
+++ b/tests/test_font_collection.py
@@ -73,7 +73,7 @@ class TestFontExportLoad:
         # Load it back
         loaded_document = SVGDocument.load(
             cast(str, exported["svg"]),
-            cast(list[bytes], exported["images"]),
+            cast(dict[str, bytes], exported["images"]),
             cast(list[dict[str, str | float]], exported["fonts"]),
         )
 
@@ -95,7 +95,7 @@ class TestFontExportLoad:
 
         # Load without fonts parameter
         loaded_document = SVGDocument.load(
-            cast(str, exported["svg"]), cast(list[bytes], exported["images"])
+            cast(str, exported["svg"]), cast(dict[str, bytes], exported["images"])
         )
 
         # Should have empty fonts list

--- a/tests/test_svg_document.py
+++ b/tests/test_svg_document.py
@@ -168,7 +168,7 @@ class TestSVGDocumentImageHandling:
         svg_elem = ET.Element("svg")
         ET.SubElement(svg_elem, "rect", x="10", y="10", width="80", height="80")
 
-        document = SVGDocument(svg=svg_elem, images=[], fonts=[])
+        document = SVGDocument(svg=svg_elem, images={}, fonts=[])
 
         # Should work with no parameters (embed_images=True by default)
         result = document.tostring()
@@ -180,10 +180,12 @@ class TestSVGDocumentImageHandling:
     def test_tostring_default_with_images(self) -> None:
         """Test tostring() with default parameters embeds images."""
         svg_elem = ET.Element("svg")
-        ET.SubElement(svg_elem, "image")
+        ET.SubElement(svg_elem, "image", id="image")
 
         document = SVGDocument(
-            svg=svg_elem, images=[Image.new("RGB", (10, 10), color="red")], fonts=[]
+            svg=svg_elem,
+            images={"image": Image.new("RGB", (10, 10), color="red")},
+            fonts=[],
         )
 
         # Should embed images by default
@@ -195,10 +197,12 @@ class TestSVGDocumentImageHandling:
     def test_tostring_embed_images_false_no_prefix_raises_error(self) -> None:
         """Test tostring() with embed_images=False and no prefix raises error."""
         svg_elem = ET.Element("svg")
-        ET.SubElement(svg_elem, "image")
+        ET.SubElement(svg_elem, "image", id="image")
 
         document = SVGDocument(
-            svg=svg_elem, images=[Image.new("RGB", (10, 10), color="red")], fonts=[]
+            svg=svg_elem,
+            images={"image": Image.new("RGB", (10, 10), color="red")},
+            fonts=[],
         )
 
         # Should raise ValueError when images exist but no output method specified
@@ -211,10 +215,12 @@ class TestSVGDocumentImageHandling:
     def test_tostring_with_image_prefix_saves_files(self, tmp_path: Path) -> None:
         """Test tostring() with image_prefix saves images to files."""
         svg_elem = ET.Element("svg")
-        ET.SubElement(svg_elem, "image")
+        ET.SubElement(svg_elem, "image", id="image")
 
         document = SVGDocument(
-            svg=svg_elem, images=[Image.new("RGB", (10, 10), color="blue")], fonts=[]
+            svg=svg_elem,
+            images={"image": Image.new("RGB", (10, 10), color="blue")},
+            fonts=[],
         )
 
         # Use image_prefix to save files
@@ -233,7 +239,7 @@ class TestSVGDocumentImageHandling:
         svg_elem = ET.Element("svg")
         ET.SubElement(svg_elem, "rect")
 
-        document = SVGDocument(svg=svg_elem, images=[], fonts=[])
+        document = SVGDocument(svg=svg_elem, images={}, fonts=[])
 
         # Should work with any combination when no images
         result1 = document.tostring(embed_images=True)
@@ -253,7 +259,7 @@ class TestSVGDocumentEmbedFonts:
         svg_elem = ET.Element("svg")
         ET.SubElement(svg_elem, "rect")
 
-        document = SVGDocument(svg=svg_elem, images=[], fonts=[])
+        document = SVGDocument(svg=svg_elem, images={}, fonts=[])
         result = document.tostring(embed_images=True, embed_fonts=False)
 
         assert "<style>" not in result
@@ -264,7 +270,7 @@ class TestSVGDocumentEmbedFonts:
         svg_elem = ET.Element("svg")
         ET.SubElement(svg_elem, "rect")
 
-        document = SVGDocument(svg=svg_elem, images=[], fonts=[])
+        document = SVGDocument(svg=svg_elem, images={}, fonts=[])
         result = document.tostring(embed_images=True, embed_fonts=True)
 
         assert "<style>" not in result
@@ -288,7 +294,7 @@ class TestSVGDocumentEmbedFonts:
             weight=80.0,
         )
 
-        document = SVGDocument(svg=svg_elem, images=[], fonts=[font])
+        document = SVGDocument(svg=svg_elem, images={}, fonts=[font])
         result = document.tostring(embed_images=True, embed_fonts=True)
 
         assert "<style>" in result
@@ -317,7 +323,7 @@ class TestSVGDocumentEmbedFonts:
             weight=80.0,
         )
 
-        document = SVGDocument(svg=svg_elem, images=[], fonts=[font])
+        document = SVGDocument(svg=svg_elem, images={}, fonts=[font])
         document.save(str(output_file), embed_images=True, embed_fonts=True)
 
         content = output_file.read_text()
@@ -352,7 +358,7 @@ class TestSVGDocumentEmbedFonts:
             weight=80.0,
         )
 
-        document = SVGDocument(svg=svg_elem, images=[], fonts=[font1, font2])
+        document = SVGDocument(svg=svg_elem, images={}, fonts=[font1, font2])
         result = document.tostring(embed_images=True, embed_fonts=True)
 
         # Should only encode once
@@ -380,7 +386,7 @@ class TestSVGDocumentEmbedFonts:
             weight=80.0,
         )
 
-        document = SVGDocument(svg=svg_elem, images=[], fonts=[font])
+        document = SVGDocument(svg=svg_elem, images={}, fonts=[font])
 
         # Call tostring twice
         document.tostring(embed_images=True, embed_fonts=True)
@@ -405,7 +411,7 @@ class TestSVGDocumentEmbedFonts:
             weight=80.0,
         )
 
-        document = SVGDocument(svg=svg_elem, images=[], fonts=[font])
+        document = SVGDocument(svg=svg_elem, images={}, fonts=[font])
         result = document.tostring(embed_images=True, embed_fonts=True)
 
         # Should not raise exception
@@ -447,7 +453,7 @@ class TestSVGDocumentEmbedFonts:
             weight=80.0,
         )
 
-        document = SVGDocument(svg=svg_elem, images=[], fonts=[font1, font2])
+        document = SVGDocument(svg=svg_elem, images={}, fonts=[font1, font2])
         result = document.tostring(embed_images=True, embed_fonts=True)
 
         assert result.count("@font-face") == 2
@@ -479,7 +485,7 @@ class TestSVGDocumentRasterizeWithFonts:
             weight=80.0,
         )
 
-        document = SVGDocument(svg=svg_elem, images=[], fonts=[font])
+        document = SVGDocument(svg=svg_elem, images={}, fonts=[font])
 
         with patch.object(ResvgRasterizer, "from_string") as mock_from_string:
             mock_from_string.return_value = Image.new("RGBA", (100, 100))
@@ -521,7 +527,7 @@ class TestSVGDocumentRasterizeWithFonts:
             weight=80.0,
         )
 
-        document = SVGDocument(svg=svg_elem, images=[], fonts=[font])
+        document = SVGDocument(svg=svg_elem, images={}, fonts=[font])
 
         with patch.object(PlaywrightRasterizer, "from_string") as mock_from_string:
             mock_from_string.return_value = Image.new("RGBA", (100, 100))


### PR DESCRIPTION
## Summary

This PR refactors the image handling system to use ID-based mapping instead of fragile index-based mapping. This makes the relationship between `<image>` SVG elements and PIL Image objects more explicit and robust.

## Problem

The previous implementation used index-based mapping between `<image>` SVG elements and PIL Image objects via `zip(nodes, self.images)`. This was fragile and relied on document order being preserved.

## Solution

1. Changed `Converter.images` and `SVGDocument.images` from `list[Image.Image]` to `dict[str, Image.Image]`
2. Added unique `id` attributes to all `<image>` SVG elements using `auto_id("image")`
3. Updated all image handling methods to use ID-based lookup instead of index-based zipping
4. Simplified `export()`/`load()` to use dict-based serialization format (no backward compatibility needed in alpha)

## Changes

### Core Changes
- Updated 5 image creation sites to generate IDs and use dict storage:
  - Flat PSD images ([converter.py:112-119](https://github.com/kyamagu/psd2svg/pull/XXX/files#diff-converter))
  - Pixel layers ([layer.py:136-137](https://github.com/kyamagu/psd2svg/pull/XXX/files#diff-layer))
  - Layer masks ([layer.py:549-550](https://github.com/kyamagu/psd2svg/pull/XXX/files#diff-layer))
  - Pattern fills ([paint.py:368-385](https://github.com/kyamagu/psd2svg/pull/XXX/files#diff-paint))

### Image Handling
- Updated `_handle_images()` to validate all `<image>` elements have IDs
- Updated `_embed_images_as_data_uris()` to lookup images by ID
- Updated `_save_images_to_files()` to lookup images by ID

### Serialization
- Updated `export()` to return `dict[str, bytes]` for images
- Updated `load()` to accept `dict[str, bytes]` for images
- No backward compatibility needed (library is in alpha state)

### Type Definitions
- Updated `ConverterProtocol.images` type definition
- Updated all related type hints

### Tests
- Updated test fixtures to use dict-based images with IDs
- Updated type casts in serialization tests

## Benefits

✅ **Robust**: Order-independent mapping via explicit IDs  
✅ **Debuggable**: Clear error messages for missing IDs/images  
✅ **Maintainable**: SVG can be modified without breaking references  
✅ **Simpler**: No conversion between dict and list formats  
✅ **Type-safe**: Full type checking with mypy  

## Testing

- ✅ All 432 tests pass
- ✅ Type checking (mypy) passes with no issues
- ✅ Linting (ruff) passes with no issues
- ✅ No breaking changes to public API (except serialization format, which is acceptable in alpha)

## Breaking Changes

⚠️ **Serialization Format Change**: The `export()` method now returns `dict[str, bytes]` for images instead of `list[bytes]`, and `load()` expects `dict[str, bytes]` instead of `list[bytes]`. This is acceptable since the library is in alpha state (v0.3.0).

Users who use `export()`/`load()` for serialization will need to update their code, but this is a straightforward change.