### PR TITLE
Add SVG optimization with consolidate_defs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,65 @@ Both ResvgRasterizer and PlaywrightRasterizer support all three platforms for SV
 
 ### Advanced Options
 
+#### SVG Optimization
+
+The library includes SVG optimization features that improve document structure, reduce file size, and enhance rendering performance. Optimization is **enabled by default** when saving or converting SVG documents.
+
+**Consolidate Definitions (enabled by default):**
+
+Merges all `<defs>` elements and moves definition elements (filters, gradients, patterns, etc.) into a single global `<defs>` at the beginning of the SVG document. This follows SVG best practices and improves browser parsing performance.
+
+```python
+from psd2svg import SVGDocument
+from psd_tools import PSDImage
+
+psdimage = PSDImage.open("input.psd")
+document = SVGDocument.from_psd(psdimage)
+
+# Optimization is enabled by default
+document.save('output.svg')  # Automatically optimized
+svg_string = document.tostring()  # Automatically optimized
+
+# Explicitly control optimization
+document.save('output.svg', optimize=True)  # Explicitly enable (default)
+document.save('output.svg', optimize=False)  # Disable optimization
+
+# Or use the optimize() method directly
+document.optimize()  # Apply optimizations in-place
+```
+
+**What gets consolidated:**
+
+- `<defs>` - Contents merged into global defs
+- `<filter>` - Filter definitions
+- `<linearGradient>` and `<radialGradient>` - Gradient definitions
+- `<pattern>` - Pattern definitions
+- `<clipPath>` - Clipping paths
+- `<marker>` - Marker definitions
+- `<symbol>` - Symbol definitions
+
+**Note:** `<mask>` elements are NOT moved as they can contain rendered content.
+
+**Benefits:**
+
+- Cleaner, more maintainable SVG structure
+- Better browser parsing performance
+- Easier debugging (all definitions in one place)
+- Follows SVG best practices
+- Slight file size reduction (fewer `<defs>` tags)
+
+**Fine-grained control:**
+
+```python
+# Use the optimize() method for more control
+document.optimize(
+    consolidate_defs=True,  # Consolidate definitions (default: True)
+    deduplicate_defs=False,  # Remove duplicates (not yet implemented)
+    minify_ids=False,        # Shorten IDs (not yet implemented)
+    remove_unused=False,     # Remove unused defs (not yet implemented)
+)
+```
+
 #### Text Letter Spacing Offset
 
 Photoshop and SVG renderers may have slightly different default letter spacing due to differences in kerning algorithms. You can compensate for these differences using the `text_letter_spacing_offset` parameter:

--- a/tests/test_optimize.py
+++ b/tests/test_optimize.py
@@ -1,0 +1,534 @@
+"""Tests for SVG optimization features."""
+
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+from psd2svg import svg_utils
+
+
+def get_local_tag(element: ET.Element) -> str:
+    """Get local tag name without namespace."""
+    tag = element.tag
+    return tag.split("}")[-1] if "}" in tag else tag
+
+
+class TestConsolidateDefs:
+    """Tests for consolidate_defs optimization."""
+
+    def test_consolidate_single_defs(self) -> None:
+        """Test consolidating a single <defs> element."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <rect fill="url(#g1)"/>
+            <defs>
+                <linearGradient id="g1"/>
+            </defs>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have one <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        # Should contain the gradient
+        assert len(svg[0]) == 1
+        assert get_local_tag(svg[0][0]) == "linearGradient"
+        assert svg[0][0].get("id") == "g1"
+        # Rect should be second child
+        assert get_local_tag(svg[1]) == "rect"
+
+    def test_consolidate_multiple_defs(self) -> None:
+        """Test consolidating multiple <defs> elements."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <defs>
+                <linearGradient id="g1"/>
+            </defs>
+            <rect fill="url(#g1)"/>
+            <defs>
+                <filter id="f1"/>
+            </defs>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have one <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        # Should contain both elements
+        assert len(svg[0]) == 2
+        assert get_local_tag(svg[0][0]) == "linearGradient"
+        assert get_local_tag(svg[0][1]) == "filter"
+        # Only one defs element total
+        defs_count = sum(1 for child in svg if get_local_tag(child) == "defs")
+        assert defs_count == 1
+
+    def test_consolidate_nested_defs(self) -> None:
+        """Test consolidating nested <defs> within groups."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <g>
+                <defs>
+                    <linearGradient id="g1"/>
+                </defs>
+                <rect fill="url(#g1)"/>
+            </g>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have global <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        assert len(svg[0]) == 1
+        assert get_local_tag(svg[0][0]) == "linearGradient"
+        # Group should no longer contain defs
+        group = svg[1]
+        assert get_local_tag(group) == "g"
+        assert len(group) == 1
+        assert get_local_tag(group[0]) == "rect"
+
+    def test_consolidate_inline_filters(self) -> None:
+        """Test consolidating inline <filter> elements."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <rect filter="url(#f1)"/>
+            <filter id="f1">
+                <feGaussianBlur stdDeviation="2"/>
+            </filter>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        # Filter should be inside defs
+        assert len(svg[0]) == 1
+        assert get_local_tag(svg[0][0]) == "filter"
+        assert svg[0][0].get("id") == "f1"
+        # Filter's children should be preserved
+        assert len(svg[0][0]) == 1
+        assert get_local_tag(svg[0][0][0]) == "feGaussianBlur"
+
+    def test_consolidate_inline_gradients(self) -> None:
+        """Test consolidating inline gradient elements."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <rect fill="url(#g1)"/>
+            <linearGradient id="g1">
+                <stop offset="0%" stop-color="#fff"/>
+                <stop offset="100%" stop-color="#000"/>
+            </linearGradient>
+            <circle fill="url(#g2)"/>
+            <radialGradient id="g2">
+                <stop offset="0%" stop-color="#f00"/>
+            </radialGradient>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        # Should contain both gradients
+        assert len(svg[0]) == 2
+        assert get_local_tag(svg[0][0]) == "linearGradient"
+        assert svg[0][0].get("id") == "g1"
+        assert get_local_tag(svg[0][1]) == "radialGradient"
+        assert svg[0][1].get("id") == "g2"
+        # Gradient children should be preserved
+        assert len(svg[0][0]) == 2  # Two stops
+        assert len(svg[0][1]) == 1  # One stop
+
+    def test_consolidate_patterns(self) -> None:
+        """Test consolidating <pattern> elements."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <rect fill="url(#p1)"/>
+            <pattern id="p1">
+                <circle cx="5" cy="5" r="5"/>
+            </pattern>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        # Pattern should be inside defs
+        assert len(svg[0]) == 1
+        assert get_local_tag(svg[0][0]) == "pattern"
+        assert svg[0][0].get("id") == "p1"
+
+    def test_consolidate_clip_paths(self) -> None:
+        """Test consolidating <clipPath> elements."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <rect clip-path="url(#c1)"/>
+            <clipPath id="c1">
+                <circle cx="50" cy="50" r="50"/>
+            </clipPath>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        # ClipPath should be inside defs
+        assert len(svg[0]) == 1
+        assert get_local_tag(svg[0][0]) == "clipPath"
+        assert svg[0][0].get("id") == "c1"
+
+    def test_consolidate_markers(self) -> None:
+        """Test consolidating <marker> elements."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <line marker-end="url(#arrow)"/>
+            <marker id="arrow">
+                <path d="M 0 0 L 10 5 L 0 10 z"/>
+            </marker>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        # Marker should be inside defs
+        assert len(svg[0]) == 1
+        assert get_local_tag(svg[0][0]) == "marker"
+        assert svg[0][0].get("id") == "arrow"
+
+    def test_consolidate_symbols(self) -> None:
+        """Test consolidating <symbol> elements."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <use href="#icon"/>
+            <symbol id="icon">
+                <circle cx="5" cy="5" r="5"/>
+            </symbol>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        # Symbol should be inside defs
+        assert len(svg[0]) == 1
+        assert get_local_tag(svg[0][0]) == "symbol"
+        assert svg[0][0].get("id") == "icon"
+
+    def test_consolidate_mixed_definitions(self) -> None:
+        """Test consolidating mixed definition types."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <filter id="f1"/>
+            <rect fill="url(#g1)" filter="url(#f1)"/>
+            <linearGradient id="g1"/>
+            <defs>
+                <pattern id="p1"/>
+            </defs>
+            <clipPath id="c1"/>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        # Should contain all 4 definitions
+        assert len(svg[0]) == 4
+        ids = {child.get("id") for child in svg[0]}
+        assert ids == {"f1", "g1", "p1", "c1"}
+        # Rect should be second child
+        assert get_local_tag(svg[1]) == "rect"
+
+    def test_consolidate_preserves_order(self) -> None:
+        """Test that consolidation preserves definition order."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <linearGradient id="g1"/>
+            <filter id="f1"/>
+            <pattern id="p1"/>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Order should be preserved
+        assert svg[0][0].get("id") == "g1"
+        assert svg[0][1].get("id") == "f1"
+        assert svg[0][2].get("id") == "p1"
+
+    def test_consolidate_empty_svg(self) -> None:
+        """Test consolidating an SVG with no definitions."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <rect x="0" y="0" width="100" height="100"/>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should not create empty <defs>
+        assert get_local_tag(svg[0]) == "rect"
+        defs_count = sum(1 for child in svg if get_local_tag(child) == "defs")
+        assert defs_count == 0
+
+    def test_consolidate_removes_empty_defs(self) -> None:
+        """Test that empty <defs> elements are removed."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <defs></defs>
+            <rect x="0" y="0" width="100" height="100"/>
+            <defs></defs>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should not have any <defs>
+        defs_count = sum(1 for child in svg if get_local_tag(child) == "defs")
+        assert defs_count == 0
+        # Should still have rect
+        assert get_local_tag(svg[0]) == "rect"
+
+    def test_consolidate_with_existing_global_defs(self) -> None:
+        """Test consolidating when a global <defs> already exists."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <defs>
+                <linearGradient id="g1"/>
+            </defs>
+            <filter id="f1"/>
+            <rect/>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have one <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        # Should contain both elements
+        assert len(svg[0]) == 2
+        assert svg[0][0].get("id") == "g1"
+        assert svg[0][1].get("id") == "f1"
+
+    def test_consolidate_deeply_nested(self) -> None:
+        """Test consolidating definitions nested deep in the tree."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <g>
+                <g>
+                    <g>
+                        <filter id="f1"/>
+                        <rect filter="url(#f1)"/>
+                    </g>
+                </g>
+            </g>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        assert len(svg[0]) == 1
+        assert svg[0][0].get("id") == "f1"
+        # Filter should be removed from nested location
+        innermost_g = svg[1][0][0]
+        assert len(innermost_g) == 1
+        assert get_local_tag(innermost_g[0]) == "rect"
+
+    def test_consolidate_does_not_move_masks(self) -> None:
+        """Test that <mask> elements are NOT moved (they can contain rendered content)."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <rect mask="url(#m1)"/>
+            <mask id="m1">
+                <rect fill="white"/>
+            </mask>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Mask should NOT be moved to defs
+        # If there are no other definitions, defs shouldn't be created
+        if svg[0].tag == "defs":
+            assert len(svg[0]) == 0  # Defs should be empty
+        # Mask should still be at top level
+        mask_found = False
+        for child in svg:
+            if get_local_tag(child) == "mask":
+                mask_found = True
+                break
+        assert mask_found
+
+    def test_consolidate_complex_real_world_example(self) -> None:
+        """Test consolidating a complex real-world-like SVG."""
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <image filter="url(#coloroverlay)"/>
+            <filter id="coloroverlay">
+                <feFlood flood-color="#ff0000"/>
+                <feComposite operator="in" in2="SourceAlpha"/>
+            </filter>
+            <mask id="mask">
+                <defs>
+                    <image id="image_2"/>
+                </defs>
+                <use href="#image_2"/>
+                <filter id="stroke">
+                    <feMorphology operator="erode" radius="1"/>
+                    <feComposite operator="xor" in2="SourceAlpha"/>
+                </filter>
+                <use href="#image_2" filter="url(#stroke)"/>
+            </mask>
+            <linearGradient id="gradient">
+                <stop offset="0%" stop-color="#fff"/>
+            </linearGradient>
+            <use href="#image_2"/>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        svg_utils.consolidate_defs(svg)
+
+        # Should have <defs> as first child
+        assert get_local_tag(svg[0]) == "defs"
+        # Should contain: coloroverlay filter, image_2, stroke filter, gradient
+        assert len(svg[0]) == 4
+        ids = {child.get("id") for child in svg[0]}
+        assert ids == {"coloroverlay", "image_2", "stroke", "gradient"}
+        # Mask should still exist but its nested defs should be gone
+        mask = None
+        for child in svg:
+            if get_local_tag(child) == "mask":
+                mask = child
+                break
+        assert mask is not None
+        # Mask should not contain any defs elements
+        mask_defs = [child for child in mask if get_local_tag(child) == "defs"]
+        assert len(mask_defs) == 0
+
+
+class TestSVGDocumentOptimize:
+    """Tests for SVGDocument.optimize() method."""
+
+    def test_optimize_method_exists(self) -> None:
+        """Test that optimize method exists and is callable."""
+        from psd2svg import SVGDocument
+
+        # Create minimal SVG document
+        svg = ET.Element("svg")
+        doc = SVGDocument(svg=svg)
+        assert hasattr(doc, "optimize")
+        assert callable(doc.optimize)
+
+    def test_optimize_consolidates_defs_by_default(self) -> None:
+        """Test that optimize() consolidates defs by default."""
+        from psd2svg import SVGDocument
+
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <filter id="f1"/>
+            <rect filter="url(#f1)"/>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        doc = SVGDocument(svg=svg)
+        doc.optimize()
+
+        # Should have consolidated defs
+        assert doc.svg[0].tag == "defs"
+        assert len(doc.svg[0]) == 1
+        assert doc.svg[0][0].get("id") == "f1"
+
+    def test_optimize_with_consolidate_defs_false(self) -> None:
+        """Test that optimize() respects consolidate_defs=False."""
+        from psd2svg import SVGDocument
+
+        svg_str = """
+        <svg xmlns="http://www.w3.org/2000/svg">
+            <filter id="f1"/>
+            <rect filter="url(#f1)"/>
+        </svg>
+        """
+        svg = ET.fromstring(svg_str)
+        doc = SVGDocument(svg=svg)
+        doc.optimize(consolidate_defs=False)
+
+        # Should NOT have consolidated defs
+        assert get_local_tag(doc.svg[0]) == "filter"
+
+    def test_tostring_with_optimize_true(self) -> None:
+        """Test that tostring() optimizes when optimize=True."""
+        from psd2svg import SVGDocument
+
+        svg_str = (
+            """<svg xmlns="http://www.w3.org/2000/svg"><filter id="f1"/><rect/></svg>"""
+        )
+        svg = ET.fromstring(svg_str)
+        doc = SVGDocument(svg=svg)
+        result = doc.tostring(embed_images=False, optimize=True)
+
+        # Should contain <defs> element (check for namespace prefix or plain tag)
+        assert "<defs>" in result or "<ns0:defs>" in result
+        assert 'filter id="f1"' in result  # Check for attribute, not full tag
+
+    def test_tostring_with_optimize_false(self) -> None:
+        """Test that tostring() skips optimization when optimize=False."""
+        from psd2svg import SVGDocument
+
+        svg_str = (
+            """<svg xmlns="http://www.w3.org/2000/svg"><filter id="f1"/><rect/></svg>"""
+        )
+        svg = ET.fromstring(svg_str)
+        doc = SVGDocument(svg=svg)
+        result = doc.tostring(embed_images=False, optimize=False)
+
+        # Should NOT have moved filter to defs (check for namespace prefix or plain tag)
+        filter_pos = max(result.find("<filter"), result.find("<ns0:filter"))
+        rect_pos = max(result.find("<rect"), result.find("<ns0:rect"))
+        assert filter_pos < rect_pos
+
+    def test_save_with_optimize_true(self, tmp_path: Path) -> None:
+        """Test that save() optimizes when optimize=True."""
+        from psd2svg import SVGDocument
+
+        svg_str = (
+            """<svg xmlns="http://www.w3.org/2000/svg"><filter id="f1"/><rect/></svg>"""
+        )
+        svg = ET.fromstring(svg_str)
+        doc = SVGDocument(svg=svg)
+
+        output_file = tmp_path / "test.svg"
+        doc.save(str(output_file), embed_images=True, optimize=True)
+
+        # Read back and verify
+        content = output_file.read_text()
+        assert "<defs>" in content or "<ns0:defs>" in content
+        assert 'filter id="f1"' in content
+
+    def test_save_with_optimize_false(self, tmp_path: Path) -> None:
+        """Test that save() skips optimization when optimize=False."""
+        from psd2svg import SVGDocument
+
+        svg_str = (
+            """<svg xmlns="http://www.w3.org/2000/svg"><filter id="f1"/><rect/></svg>"""
+        )
+        svg = ET.fromstring(svg_str)
+        doc = SVGDocument(svg=svg)
+
+        output_file = tmp_path / "test.svg"
+        doc.save(str(output_file), embed_images=True, optimize=False)
+
+        # Read back and verify
+        content = output_file.read_text()
+        # Should NOT have moved filter to defs
+        filter_pos = max(content.find("<filter"), content.find("<ns0:filter"))
+        rect_pos = max(content.find("<rect"), content.find("<ns0:rect"))
+        assert filter_pos < rect_pos


### PR DESCRIPTION
## Summary

Adds SVG optimization feature to improve document structure and follow SVG best practices.

### Key Changes

- **New `consolidate_defs()` function** in `svg_utils.py`:
  - Merges all `<defs>` elements into a single global `<defs>` at the beginning of the SVG
  - Moves definition elements (filters, gradients, patterns, clipPath, markers, symbols) into global defs
  - Removes now-empty inline `<defs>` elements
  - Preserves element ordering and ID references
  - Does NOT move `<mask>` elements (they can contain rendered content)

- **New `SVGDocument.optimize()` method**:
  - Single parameter: `consolidate_defs` (default: `True`)
  - Applies optimizations in-place to the SVG element tree
  - Extensible design for future optimizations

- **Updated `save()` and `tostring()` methods**:
  - New `optimize` parameter (default: `True`)
  - Automatically applies optimizations when saving or converting to string
  - Can be disabled with `optimize=False`

- **Comprehensive test suite**:
  - 24 tests covering all optimization scenarios
  - Tests for single/multiple/nested defs consolidation
  - Tests for all definition element types
  - Edge case testing (empty SVG, deeply nested, masks)
  - Integration tests with SVGDocument API

- **Documentation**:
  - Added SVG Optimization section to CLAUDE.md
  - Usage examples and best practices
  - Clear explanation of benefits and behavior

### Benefits

- **Cleaner SVG structure**: All definitions consolidated in one location
- **Better browser parsing**: Following SVG best practices improves rendering performance
- **Easier debugging**: All definitions visible at the beginning of the document
- **Opt-out design**: Enabled by default but can be disabled if needed

### Testing

- ✅ All 24 new optimization tests passing
- ✅ All 432 existing tests passing (30 skipped)
- ✅ Type checking passing (mypy)
- ✅ Linting passing (ruff)
- ✅ Code formatting correct

### Breaking Changes

None - this is a new feature with optimization enabled by default. Users can disable with `optimize=False` if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)