### PR TITLE
Fix blend subtraction constant

### DIFF
--- a/src/psd2svg/core/constants.py
+++ b/src/psd2svg/core/constants.py
@@ -56,7 +56,7 @@ BLEND_MODE: dict[Union[BlendMode, bytes], str] = {
     b"hardMix": "normal",
     Enum.Difference: "difference",
     Enum.Exclusion: "exclusion",
-    Enum.Subtract: "difference",
+    b"blendSubtraction": "difference",
     b"blendDivide": "difference",
     Enum.Hue: "hue",
     Enum.Saturation: "saturation",
@@ -92,7 +92,7 @@ INACCURATE_BLEND_MODES: set[Union[BlendMode, bytes]] = {
     b"hardMix",
     # Subtract and Divide modes approximated with difference
     BlendMode.SUBTRACT,
-    Enum.Subtract,
+    b"blendSubtraction",
     BlendMode.DIVIDE,
     b"blendDivide",
 }


### PR DESCRIPTION
## Summary

Fixes incorrect constant usage for blend subtraction mode in both `BLEND_MODE` dictionary and `INACCURATE_BLEND_MODES` set.

## Changes

- Changed `Enum.Subtract` to `b"blendSubtraction"` in `BLEND_MODE` dictionary (line 59)
- Changed `Enum.Subtract` to `b"blendSubtraction"` in `INACCURATE_BLEND_MODES` set (line 95)

## Why

The PSD descriptor values use `b"blendSubtraction"` as the actual constant, not `Enum.Subtract`. This inconsistency was causing the xfail marker in `test_convert.py` to catch incorrect exceptions, as the blend mode warning system wasn't properly recognizing subtraction blend modes.

## Testing

- ✅ Formatting: `uv run ruff format src/ tests/`
- ✅ Linting: `uv run ruff check src/ tests/`
- ✅ Type checking: `uv run mypy src/ tests/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)