### PR TITLE
Add enable_class flag to control class attribute insertion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,6 +119,54 @@ document.optimize(
 )
 ```
 
+#### Class Attribute Control
+
+By default, the converter does not add class attributes to SVG elements for cleaner, minimal output. You can enable class attribute insertion for debugging purposes using the `enable_class` parameter:
+
+**Python API:**
+
+```python
+from psd2svg import SVGDocument, convert
+from psd_tools import PSDImage
+
+psdimage = PSDImage.open("input.psd")
+
+# Option 1: Enable class attributes via SVGDocument
+document = SVGDocument.from_psd(psdimage, enable_class=True)
+document.save('output.svg')
+
+# Option 2: Enable via convert() function
+convert('input.psd', 'output.svg', enable_class=True)
+```
+
+**Command Line:**
+
+```bash
+# Enable class attributes for debugging
+psd2svg input.psd output.svg --enable-class
+```
+
+**Class attributes added when enabled:**
+
+- **Layer types**: `group`, `pixel-layer`, `shape-layer`, `type-layer`, `artboard`
+- **Effects**: `drop-shadow-effect`, `outer-glow-effect`, `color-overlay-effect`, `gradient-overlay-effect`, `pattern-overlay-effect`, `stroke-effect`, `inner-shadow-effect`, `inner-glow-effect`
+- **Semantic roles**: `fill`, `stroke`, `text-content`, `clipping`, `clipping-base`, `layer-mask`
+- **Adjustment layers**: `invert`, etc.
+
+**When to enable class attributes:**
+
+- ✅ Debugging SVG output to identify layer types
+- ✅ Targeting specific elements with CSS for styling
+- ✅ JavaScript manipulation of specific layer types
+- ✅ Understanding the SVG structure
+
+**When to keep disabled (default):**
+
+- ✅ Cleaner, more minimal SVG output
+- ✅ Smaller file size (modest reduction)
+- ✅ Production SVG files
+- ✅ When class attributes are not needed
+
 #### Text Letter Spacing Offset
 
 Photoshop and SVG renderers may have slightly different default letter spacing due to differences in kerning algorithms. You can compensate for these differences using the `text_letter_spacing_offset` parameter:

--- a/src/psd2svg/__main__.py
+++ b/src/psd2svg/__main__.py
@@ -44,6 +44,12 @@ def parse_args() -> argparse.Namespace:
         help="Disable insertion of <title> elements with layer names.",
     )
     parser.add_argument(
+        "--enable-class",
+        dest="enable_class",
+        action="store_true",
+        help="Enable insertion of class attributes on SVG elements for debugging.",
+    )
+    parser.add_argument(
         "--image-format",
         metavar="FORMAT",
         type=str,
@@ -78,6 +84,7 @@ def main() -> None:
         enable_text=args.enable_text,
         enable_live_shapes=args.enable_live_shapes,
         enable_title=args.enable_title,
+        enable_class=args.enable_class,
         image_format=args.image_format,
         text_letter_spacing_offset=args.text_letter_spacing_offset,
     )

--- a/src/psd2svg/core/base.py
+++ b/src/psd2svg/core/base.py
@@ -25,6 +25,7 @@ class ConverterProtocol(Protocol):
     enable_live_shapes: bool
     enable_text: bool
     enable_title: bool
+    enable_class: bool
 
     def add_layer(self, layer: layers.Layer, **attrib: str) -> ET.Element | None: ...
     def add_group(self, layer: layers.Group, **attrib: str) -> ET.Element | None: ...

--- a/src/psd2svg/core/converter.py
+++ b/src/psd2svg/core/converter.py
@@ -54,6 +54,11 @@ class Converter(
             (default), each layer in the SVG will have a <title> element containing the
             Photoshop layer name for accessibility and debugging. Set to False to omit
             title elements and reduce file size.
+        enable_class: Enable insertion of class attributes on SVG elements for debugging
+            purposes. When False (default), elements will not have class attributes,
+            producing cleaner SVG output. Set to True to add class attributes for layer
+            types, effects, and semantic roles (e.g., "shape-layer", "drop-shadow-effect",
+            "fill") for debugging or styling.
         text_letter_spacing_offset: Global offset (in pixels) to add to all letter-spacing
             values. This can be used to compensate for differences between Photoshop's
             text rendering and SVG's text rendering. Typical values range from -0.02 to 0.02.
@@ -72,6 +77,7 @@ class Converter(
         enable_live_shapes: bool = True,
         enable_text: bool = True,
         enable_title: bool = True,
+        enable_class: bool = False,
         text_letter_spacing_offset: float = 0.0,
         text_wrapping_mode: int = 0,
     ) -> None:
@@ -84,6 +90,7 @@ class Converter(
         self.enable_live_shapes = enable_live_shapes
         self.enable_text = enable_text
         self.enable_title = enable_title
+        self.enable_class = enable_class
         self.text_letter_spacing_offset = text_letter_spacing_offset
         self.text_wrapping_mode = text_wrapping_mode
 
@@ -155,6 +162,10 @@ class Converter(
         """
         if parent is None:
             parent = self.current
+
+        # Conditionally suppress class based on enable_class flag
+        if not self.enable_class:
+            class_ = ""
 
         # Conditionally suppress title based on enable_title flag
         if not self.enable_title:

--- a/src/psd2svg/core/layer.py
+++ b/src/psd2svg/core/layer.py
@@ -240,7 +240,8 @@ class LayerConverter(ConverterProtocol):
             with self.set_current(defs):
                 node = self.create_text_node(layer)
                 svg_utils.set_attribute(node, "id", self.auto_id("text"))
-                svg_utils.append_attribute(node, "class", layer.kind)
+                if self.enable_class:
+                    svg_utils.append_attribute(node, "class", layer.kind)
                 # Apply any additional attributes
                 for key, value in attrib.items():
                     svg_utils.set_attribute(node, key, value)
@@ -364,7 +365,8 @@ class LayerConverter(ConverterProtocol):
                 )
             # TODO: Maybe move clip-path or mask out of the outer mask container?
 
-        svg_utils.append_attribute(target, "class", "clipping-base")
+        if self.enable_class:
+            svg_utils.append_attribute(target, "class", "clipping-base")
         if "id" not in target.attrib:
             target.set("id", self.auto_id("clippingbase"))
 

--- a/src/psd2svg/svg_document.py
+++ b/src/psd2svg/svg_document.py
@@ -56,6 +56,7 @@ class SVGDocument:
         enable_live_shapes: bool = True,
         enable_text: bool = True,
         enable_title: bool = True,
+        enable_class: bool = False,
         text_letter_spacing_offset: float = 0.0,
         text_wrapping_mode: int = 0,
     ) -> "SVGDocument":
@@ -73,6 +74,11 @@ class SVGDocument:
                 When True (default), each layer in the SVG will have a <title>
                 element containing the Photoshop layer name for accessibility and
                 debugging. Set to False to omit title elements and reduce file size.
+            enable_class: Enable insertion of class attributes on SVG elements for
+                debugging purposes. When False (default), elements will not have class
+                attributes, producing cleaner SVG output. Set to True to add class
+                attributes for layer types, effects, and semantic roles (e.g.,
+                "shape-layer", "drop-shadow-effect", "fill") for debugging or styling.
             text_letter_spacing_offset: Global offset (in pixels) to add to all
                 letter-spacing values. This can be used to compensate for differences
                 between Photoshop's text rendering and SVG's text rendering. Typical
@@ -90,6 +96,7 @@ class SVGDocument:
             enable_live_shapes=enable_live_shapes,
             enable_text=enable_text,
             enable_title=enable_title,
+            enable_class=enable_class,
             text_letter_spacing_offset=text_letter_spacing_offset,
             text_wrapping_mode=text_wrapping_mode,
         )
@@ -703,6 +710,7 @@ def convert(
     enable_text: bool = True,
     enable_live_shapes: bool = True,
     enable_title: bool = True,
+    enable_class: bool = False,
     image_format: str = DEFAULT_IMAGE_FORMAT,
     text_letter_spacing_offset: float = 0.0,
     text_wrapping_mode: int = 0,
@@ -722,6 +730,11 @@ def convert(
             When True (default), each layer in the SVG will have a <title> element
             containing the Photoshop layer name for accessibility and debugging.
             Set to False to omit title elements and reduce file size.
+        enable_class: Enable insertion of class attributes on SVG elements for debugging
+            purposes. When False (default), elements will not have class attributes,
+            producing cleaner SVG output. Set to True to add class attributes for layer
+            types, effects, and semantic roles (e.g., "shape-layer", "drop-shadow-effect",
+            "fill") for debugging or styling.
         image_format: Image format to use when embedding or saving images.
             Supported formats: 'webp', 'png', 'jpeg'. Default is 'webp'.
         text_letter_spacing_offset: Global offset (in pixels) to add to all letter-spacing
@@ -740,6 +753,7 @@ def convert(
         enable_text=enable_text,
         enable_live_shapes=enable_live_shapes,
         enable_title=enable_title,
+        enable_class=enable_class,
         text_letter_spacing_offset=text_letter_spacing_offset,
         text_wrapping_mode=text_wrapping_mode,
     )

--- a/tests/test_enable_class.py
+++ b/tests/test_enable_class.py
@@ -1,0 +1,200 @@
+"""Tests for enable_class flag functionality."""
+
+from pathlib import Path
+
+import pytest
+from psd_tools import PSDImage
+
+from psd2svg import SVGDocument, convert
+from psd2svg.core.converter import Converter
+
+from .conftest import get_fixture
+
+# Use a PSD file that definitely has layers with class attributes
+TEST_PSD = "layer-types/invert.psd"
+
+
+def test_enable_class_default_false() -> None:
+    """Test that class attributes are omitted by default."""
+    psdimage = PSDImage.open(get_fixture(TEST_PSD))
+    document = SVGDocument.from_psd(psdimage)
+
+    # Verify no class attributes exist by default
+    elements_with_class = document.svg.findall(".//*[@class]")
+    assert len(elements_with_class) == 0, "Should have no class attributes by default"
+
+
+def test_enable_class_true_explicit() -> None:
+    """Test that class attributes are included when explicitly enabled."""
+    psdimage = PSDImage.open(get_fixture(TEST_PSD))
+    document = SVGDocument.from_psd(psdimage, enable_class=True)
+
+    # Find elements with class attributes
+    elements_with_class = document.svg.findall(".//*[@class]")
+    assert len(elements_with_class) > 0, "Should have elements with class attributes"
+
+
+def test_enable_class_converter_direct() -> None:
+    """Test enable_class flag at Converter level."""
+    psdimage = PSDImage.open(get_fixture(TEST_PSD))
+    converter = Converter(psdimage, enable_class=False)
+    converter.build()
+
+    elements_with_class = converter.svg.findall(".//*[@class]")
+    assert len(elements_with_class) == 0, "Should have no class attributes"
+
+
+def test_enable_class_converter_true() -> None:
+    """Test enable_class flag at Converter level when enabled."""
+    psdimage = PSDImage.open(get_fixture(TEST_PSD))
+    converter = Converter(psdimage, enable_class=True)
+    converter.build()
+
+    elements_with_class = converter.svg.findall(".//*[@class]")
+    assert len(elements_with_class) > 0, "Should have class attributes when enabled"
+
+
+def test_enable_class_false_explicit() -> None:
+    """Test explicit enable_class=False produces same result as default."""
+    psdimage = PSDImage.open(get_fixture(TEST_PSD))
+    doc_default = SVGDocument.from_psd(psdimage)
+    doc_explicit_false = SVGDocument.from_psd(psdimage, enable_class=False)
+
+    # Both should produce identical output with no class attributes
+    default_classes = doc_default.svg.findall(".//*[@class]")
+    explicit_classes = doc_explicit_false.svg.findall(".//*[@class]")
+
+    assert len(default_classes) == 0
+    assert len(explicit_classes) == 0
+    assert len(default_classes) == len(explicit_classes)
+
+
+def test_enable_class_with_layer_types() -> None:
+    """Test that layer type classes (layer.kind) are controlled by the flag."""
+    psdimage = PSDImage.open(get_fixture(TEST_PSD))
+    # Without class attributes
+    doc_without = SVGDocument.from_psd(psdimage, enable_class=False)
+    elements_without = doc_without.svg.findall(".//*[@class]")
+
+    # With class attributes
+    doc_with = SVGDocument.from_psd(psdimage, enable_class=True)
+    elements_with = doc_with.svg.findall(".//*[@class]")
+
+    # Verify the difference
+    assert len(elements_without) == 0
+    assert len(elements_with) > 0
+
+    # Check for specific layer type classes if present
+    all_classes = " ".join([el.get("class", "") for el in elements_with])
+    # Common layer types that might be present (including adjustment layers)
+    possible_kinds = [
+        "group",
+        "pixel-layer",
+        "shape-layer",
+        "type-layer",
+        "invert",
+        "adjustment",
+    ]
+    has_layer_kind = any(kind in all_classes for kind in possible_kinds)
+    if len(all_classes) > 0:
+        assert has_layer_kind, f"Should have layer kind classes, got: {all_classes}"
+
+
+def test_enable_class_convert_function(tmp_path: Path) -> None:
+    """Test convert() function with enable_class parameter."""
+    test_psd = get_fixture(TEST_PSD)
+    output_without = tmp_path / "without_class.svg"
+    output_with = tmp_path / "with_class.svg"
+
+    # Convert without class attributes (default)
+    convert(str(test_psd), str(output_without), enable_class=False)
+
+    # Convert with class attributes
+    convert(str(test_psd), str(output_with), enable_class=True)
+
+    # Parse and verify
+    import xml.etree.ElementTree as ET
+
+    tree_without = ET.parse(output_without)
+    tree_with = ET.parse(output_with)
+
+    elements_without = tree_without.findall(".//*[@class]")
+    elements_with = tree_with.findall(".//*[@class]")
+
+    assert len(elements_without) == 0
+    assert len(elements_with) > 0
+
+
+def test_enable_class_preserves_other_attributes() -> None:
+    """Test that disabling class doesn't affect other attributes."""
+    psdimage = PSDImage.open(get_fixture(TEST_PSD))
+    doc_without_class = SVGDocument.from_psd(psdimage, enable_class=False)
+    doc_with_class = SVGDocument.from_psd(psdimage, enable_class=True)
+
+    # Check that other attributes are preserved (e.g., id, width, height)
+    svg_without = doc_without_class.svg
+    svg_with = doc_with_class.svg
+
+    # SVG root should have width and height regardless of class flag
+    assert svg_without.get("width") is not None
+    assert svg_without.get("height") is not None
+    assert svg_with.get("width") is not None
+    assert svg_with.get("height") is not None
+
+    # Dimensions should be the same
+    assert svg_without.get("width") == svg_with.get("width")
+    assert svg_without.get("height") == svg_with.get("height")
+
+
+def test_enable_class_with_multiple_layers() -> None:
+    """Test enable_class with a PSD containing multiple layers."""
+    psdimage = PSDImage.open(get_fixture(TEST_PSD))
+    # Test with layers if available
+    if len(psdimage) == 0:
+        pytest.skip("No layers in test PSD")
+
+    doc_with_class = SVGDocument.from_psd(psdimage, enable_class=True)
+    elements_with_class = doc_with_class.svg.findall(".//*[@class]")
+
+    # Should have class attributes for multiple layers
+    assert len(elements_with_class) > 0
+
+    doc_without_class = SVGDocument.from_psd(psdimage, enable_class=False)
+    elements_without_class = doc_without_class.svg.findall(".//*[@class]")
+
+    # Should have no class attributes
+    assert len(elements_without_class) == 0
+
+
+def test_enable_class_independence_from_title() -> None:
+    """Test that enable_class works independently from enable_title."""
+    psdimage = PSDImage.open(get_fixture(TEST_PSD))
+    # Test all combinations
+    doc_both_false = SVGDocument.from_psd(
+        psdimage, enable_class=False, enable_title=False
+    )
+    doc_class_only = SVGDocument.from_psd(
+        psdimage, enable_class=True, enable_title=False
+    )
+    doc_title_only = SVGDocument.from_psd(
+        psdimage, enable_class=False, enable_title=True
+    )
+    doc_both_true = SVGDocument.from_psd(psdimage, enable_class=True, enable_title=True)
+
+    # Verify class attributes
+    assert len(doc_both_false.svg.findall(".//*[@class]")) == 0
+    assert len(doc_title_only.svg.findall(".//*[@class]")) == 0
+    # class_only and both_true should have class attributes if there are layers
+    class_only_count = len(doc_class_only.svg.findall(".//*[@class]"))
+    both_true_count = len(doc_both_true.svg.findall(".//*[@class]"))
+    # Both should have same number of class attributes
+    assert class_only_count == both_true_count
+
+    # Verify title elements
+    assert len(doc_both_false.svg.findall(".//title")) == 0
+    assert len(doc_class_only.svg.findall(".//title")) == 0
+    # title_only and both_true should have title elements if there are layers
+    title_only_count = len(doc_title_only.svg.findall(".//title"))
+    both_true_count_titles = len(doc_both_true.svg.findall(".//title"))
+    # Both should have same number of title elements
+    assert title_only_count == both_true_count_titles


### PR DESCRIPTION
## Summary

This PR adds an `enable_class` control flag to enable/disable class attribute annotation in the SVG output, following the same pattern as the existing `enable_title` flag.

**Key Changes:**
- Class attributes are **disabled by default** for cleaner, minimal SVG output
- Can be enabled via `enable_class=True` parameter or `--enable-class` CLI flag
- Useful for debugging and identifying layer types/effects in the SVG

## Implementation

### Files Modified

- **Core infrastructure**: [src/psd2svg/core/base.py](src/psd2svg/core/base.py), [src/psd2svg/core/converter.py](src/psd2svg/core/converter.py)
  - Added `enable_class` flag to protocol and converter
  - Added conditional check in `create_node()` to suppress class attributes when disabled

- **Dynamic appends**: [src/psd2svg/core/layer.py](src/psd2svg/core/layer.py)
  - Added conditional checks for 2 locations using `svg_utils.append_attribute()`

- **Public API**: [src/psd2svg/svg_document.py](src/psd2svg/svg_document.py)
  - Added `enable_class` parameter to `SVGDocument.from_psd()` and `convert()`

- **CLI**: [src/psd2svg/__main__.py](src/psd2svg/__main__.py)
  - Added `--enable-class` flag

- **Tests**: [tests/test_enable_class.py](tests/test_enable_class.py)
  - 10 comprehensive tests covering all use cases
  - All tests pass ✅

- **Documentation**: [CLAUDE.md](CLAUDE.md)
  - Added detailed "Class Attribute Control" section with examples

## Usage Examples

**Python API:**

```python
from psd2svg import SVGDocument, convert

# Enable class attributes for debugging
document = SVGDocument.from_psd(psdimage, enable_class=True)
convert('input.psd', 'output.svg', enable_class=True)
```

**Command Line:**

```bash
# Enable class attributes
psd2svg input.psd output.svg --enable-class
```

## Class Attributes Added (when enabled)

- **Layer types**: `group`, `pixel-layer`, `shape-layer`, `type-layer`, `artboard`
- **Effects**: `drop-shadow-effect`, `outer-glow-effect`, `color-overlay-effect`, etc.
- **Semantic roles**: `fill`, `stroke`, `text-content`, `clipping`, `layer-mask`
- **Adjustment layers**: `invert`, etc.

## Testing

✅ All formatting checks pass (ruff)  
✅ All type checks pass (mypy)  
✅ All 10 tests pass (pytest)  
✅ CLI flag works correctly

## Rationale

Class attributes are primarily useful for debugging and development, not for production SVG files. By disabling them by default:
- Cleaner, more minimal SVG output
- Smaller file size (modest reduction)
- Users can opt-in when needed for debugging

🤖 Generated with [Claude Code](https://claude.com/claude-code)