### PR TITLE
Change enable_title default from True to False

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -9,14 +9,14 @@ Title Elements
 Overview
 ~~~~~~~~
 
-By default, each layer in the SVG includes a ``<title>`` element containing the Photoshop layer name. This provides:
+By default, title elements are omitted from the SVG output to reduce file size for production workflows. When enabled, each layer includes a ``<title>`` element containing the Photoshop layer name, which provides:
 
 * Layer identification in SVG editors
 * Tooltips when hovering in browsers
 * Accessibility improvements
 * Better debugging experience
 
-**With titles enabled (default):**
+**With titles disabled (default):**
 
 .. code-block:: xml
 
@@ -29,21 +29,23 @@ By default, each layer in the SVG includes a ``<title>`` element containing the 
      <path d="M10,10 L50,50" stroke="#000000" />
    </g>
 
-**With titles disabled:**
+**With titles enabled:**
 
 .. code-block:: xml
 
    <g id="layer-1">
+     <title>Background Layer</title>
      <rect x="0" y="0" width="100" height="100" fill="#ff0000" />
    </g>
    <g id="layer-2">
+     <title>Logo</title>
      <path d="M10,10 L50,50" stroke="#000000" />
    </g>
 
-Disabling Titles
-~~~~~~~~~~~~~~~~
+Enabling Titles
+~~~~~~~~~~~~~~~
 
-Title elements increase file size. You can disable them for production:
+You can enable title elements for development and debugging:
 
 .. code-block:: python
 
@@ -51,28 +53,28 @@ Title elements increase file size. You can disable them for production:
    from psd_tools import PSDImage
 
    psdimage = PSDImage.open("input.psd")
-   document = SVGDocument.from_psd(psdimage, enable_title=False)
+   document = SVGDocument.from_psd(psdimage, enable_title=True)
    document.save("output.svg")
 
 **Command Line:**
 
 .. code-block:: bash
 
-   psd2svg input.psd output.svg --no-title
+   psd2svg input.psd output.svg --enable-title
 
-**When to disable:**
+**When to enable:**
+
+* Development/debugging
+* SVG will be opened in editors
+* Accessibility is important
+* Layer identification needed
+
+**When to keep disabled (default):**
 
 * Production builds (file size matters)
 * Minified output
 * Layer names contain sensitive information
 * SVG will not be edited further
-
-**When to keep enabled:**
-
-* Development/debugging
-* SVG will be opened in editors
-* Accessibility is important
-* File size is not critical
 
 Text Letter Spacing
 -------------------

--- a/docs/user-guide.rst
+++ b/docs/user-guide.rst
@@ -70,7 +70,7 @@ For simple one-step conversions, use the ``convert()`` convenience function:
 * ``embed_images`` (bool): Whether to embed images as data URIs (default: True if no image_prefix)
 * ``image_prefix`` (str, optional): Prefix for external image files, relative to the output SVG file's directory
 * ``image_format`` (str): Image format - 'png', 'jpeg', or 'webp' (default: 'webp')
-* ``enable_title`` (bool): Enable insertion of <title> elements with layer names (default: True)
+* ``enable_title`` (bool): Enable insertion of <title> elements with layer names (default: False)
 * ``text_letter_spacing_offset`` (float): Global offset (in pixels) to add to all letter-spacing values (default: 0.0)
 
 SVGDocument Class

--- a/src/psd2svg/__main__.py
+++ b/src/psd2svg/__main__.py
@@ -38,10 +38,10 @@ def parse_args() -> argparse.Namespace:
         help="Disable live shape conversion (use paths instead of shape primitives).",
     )
     parser.add_argument(
-        "--no-title",
+        "--enable-title",
         dest="enable_title",
-        action="store_false",
-        help="Disable insertion of <title> elements with layer names.",
+        action="store_true",
+        help="Enable insertion of <title> elements with layer names.",
     )
     parser.add_argument(
         "--enable-class",

--- a/src/psd2svg/core/converter.py
+++ b/src/psd2svg/core/converter.py
@@ -76,7 +76,7 @@ class Converter(
         psdimage: PSDImage,
         enable_live_shapes: bool = True,
         enable_text: bool = True,
-        enable_title: bool = True,
+        enable_title: bool = False,
         enable_class: bool = False,
         text_letter_spacing_offset: float = 0.0,
         text_wrapping_mode: int = 0,

--- a/src/psd2svg/svg_document.py
+++ b/src/psd2svg/svg_document.py
@@ -55,7 +55,7 @@ class SVGDocument:
         psdimage: PSDImage,
         enable_live_shapes: bool = True,
         enable_text: bool = True,
-        enable_title: bool = True,
+        enable_title: bool = False,
         enable_class: bool = False,
         text_letter_spacing_offset: float = 0.0,
         text_wrapping_mode: int = 0,
@@ -71,9 +71,9 @@ class SVGDocument:
             enable_text: Enable text layer conversion. If False, text layers
                 are rasterized as images.
             enable_title: Enable insertion of <title> elements with layer names.
-                When True (default), each layer in the SVG will have a <title>
-                element containing the Photoshop layer name for accessibility and
-                debugging. Set to False to omit title elements and reduce file size.
+                When False (default), title elements are omitted to reduce file size.
+                Set to True to include <title> elements containing the Photoshop layer
+                name for accessibility and debugging.
             enable_class: Enable insertion of class attributes on SVG elements for
                 debugging purposes. When False (default), elements will not have class
                 attributes, producing cleaner SVG output. Set to True to add class
@@ -709,7 +709,7 @@ def convert(
     image_prefix: str | None = None,
     enable_text: bool = True,
     enable_live_shapes: bool = True,
-    enable_title: bool = True,
+    enable_title: bool = False,
     enable_class: bool = False,
     image_format: str = DEFAULT_IMAGE_FORMAT,
     text_letter_spacing_offset: float = 0.0,
@@ -727,9 +727,9 @@ def convert(
             results in <path> elements instead of shape primitives like <rect> or <circle>.
             This may be more accurate, but less editable. Default is True.
         enable_title: Enable insertion of <title> elements with layer names.
-            When True (default), each layer in the SVG will have a <title> element
-            containing the Photoshop layer name for accessibility and debugging.
-            Set to False to omit title elements and reduce file size.
+            When False (default), title elements are omitted to reduce file size.
+            Set to True to include <title> elements containing the Photoshop layer
+            name for accessibility and debugging.
         enable_class: Enable insertion of class attributes on SVG elements for debugging
             purposes. When False (default), elements will not have class attributes,
             producing cleaner SVG output. Set to True to add class attributes for layer

--- a/tests/test_convert.py
+++ b/tests/test_convert.py
@@ -273,10 +273,10 @@ def test_enable_live_shapes_flag() -> None:
 
 
 def test_enable_title_flag() -> None:
-    """Test that disabling title elements works."""
+    """Test that enabling title elements works."""
     psdimage = PSDImage.open(get_fixture("layer-types/group.psd"))
 
-    # Test with enable_title=True (default behavior)
+    # Test with enable_title=True
     converter = Converter(psdimage, enable_title=True)
     converter.build()
     title_elements = converter.svg.findall(".//title")
@@ -284,7 +284,7 @@ def test_enable_title_flag() -> None:
         "Expected <title> elements in SVG with enable_title=True."
     )
 
-    # Test with enable_title=False
+    # Test with enable_title=False (default behavior)
     converter = Converter(psdimage, enable_title=False)
     converter.build()
     title_elements = converter.svg.findall(".//title")


### PR DESCRIPTION
## Summary

This PR changes the default behavior for `enable_title` from `True` to `False` to target production workflows by default, where smaller file sizes are preferred over debugging features.

## Motivation

Title elements add file size overhead and are primarily useful for development and debugging. By defaulting to `False`, the library becomes more production-ready out of the box, while still allowing developers to easily enable titles when needed.

## Changes

### Code Changes
- **src/psd2svg/svg_document.py**: Changed default from `True` to `False` in both `SVGDocument.from_psd()` and `convert()` functions, updated docstrings
- **src/psd2svg/core/converter.py**: Changed default from `True` to `False` in `Converter.__init__()`
- **src/psd2svg/__main__.py**: Changed CLI argument from `--no-title` (with `store_false`) to `--enable-title` (with `store_true`)

### Documentation Changes
- **docs/user-guide.rst**: Updated parameter description to show `(default: False)`
- **docs/configuration.rst**: Restructured to reflect disabled-by-default behavior:
  - Changed section title from "Disabling Titles" to "Enabling Titles"
  - Swapped example order (disabled first, then enabled)
  - Updated command line example to use `--enable-title`
  - Reorganized guidance for when to enable vs keep disabled

### Test Changes
- **tests/test_convert.py**: Updated test comments to reflect new defaults

## Testing

All pre-commit checks passed:
- ✅ Code formatting (ruff format)
- ✅ Linting (ruff check)
- ✅ Type checking (mypy)
- ✅ All 512 tests passed

## Migration Guide

For users who want to preserve the old behavior (titles enabled by default):

**Python API:**
```python
# Old (implicit):
document = SVGDocument.from_psd(psdimage)

# New (explicit):
document = SVGDocument.from_psd(psdimage, enable_title=True)
```

**CLI:**
```bash
# Old (implicit):
psd2svg input.psd output.svg

# New (explicit):
psd2svg input.psd output.svg --enable-title
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)