### PR TITLE
Refactor font module imports for cleaner code

### DIFF
--- a/src/psd2svg/font_subsetting.py
+++ b/src/psd2svg/font_subsetting.py
@@ -86,7 +86,6 @@ def subset_font(
 
     Raises:
         ImportError: If fonttools package is not installed.
-        ValueError: If output_format is unsupported.
         Exception: If subsetting fails (invalid font, I/O error, etc.).
 
     Example:


### PR DESCRIPTION
## Summary

- Remove unnecessary conditional import of `font_subsetting` module (fonttools is a core dependency)
- Move `font_mapping` import from function scope to module level in `FontInfo.resolve()`
- Remove redundant runtime check for font subsetting availability
- Fix docstring in `subset_font()` to remove `ValueError` that isn't explicitly raised

## Changes

### `src/psd2svg/core/font_utils.py`
- Simplified import: removed conditional `HAS_FONT_SUBSETTING` flag pattern
- Moved `font_mapping` import to top level for better performance
- Removed redundant runtime ImportError check in `encode_font_with_options()`
- Cleaned up type ignore comments

### `src/psd2svg/font_subsetting.py`
- Fixed docstring: removed `ValueError` from Raises section (not explicitly raised)

## Rationale

Since `fonttools[woff]` is a required dependency in `pyproject.toml`, the conditional import pattern adds unnecessary complexity without providing any benefit. Moving the function-level import to module level also provides a small performance improvement by avoiding repeated imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)