### PR TITLE
Update documentation for Windows font resolution support

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,6 @@ pip install psd2svg
 ### Optional Features
 
 ```bash
-# Font subsetting for web optimization (90%+ size reduction)
-pip install psd2svg[fonts]
-
 # Browser-based rasterization (better SVG 2.0 support)
 pip install psd2svg[browser]
 playwright install chromium


### PR DESCRIPTION
## Summary

- Remove obsolete `[fonts]` optional group from README.md since fonttools is now a core dependency
- Update docs/fonts.rst to document Windows font resolution support
- Remove outdated Windows workarounds (WSL, Docker) since Windows now has full support

## Changes

### README.md
- Removed `pip install psd2svg[fonts]` from Optional Features section
- fonttools is now installed automatically with psd2svg

### docs/fonts.rst
- Added platform support note in Overview section
- Updated Platform Behavior section with Windows registry + fontTools details
- Updated Font Resolution Priority to include Windows
- Rewrote Font Embedding with Custom Mappings section to show Windows support
- Removed outdated Windows workarounds
- Updated Troubleshooting section to remove [fonts] group reference

## Context

Windows font resolution was implemented in #126 via:
- Windows registry for font file discovery
- fontTools for parsing font metadata (PostScript names, weights, styles)
- Support for TrueType and OpenType fonts

This PR updates the documentation to reflect that Windows now has full parity with Linux/macOS for font resolution and embedding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)