### PR TITLE
Add optimization to merge consecutive sibling tspan elements

### DIFF
--- a/src/psd2svg/core/text.py
+++ b/src/psd2svg/core/text.py
@@ -135,6 +135,7 @@ class TextConverter(ConverterProtocol):
         svg_utils.merge_common_child_attributes(
             text_node, excludes={"x", "y", "dx", "dy", "transform"}
         )
+        svg_utils.merge_consecutive_siblings(text_node)
         svg_utils.merge_singleton_children(text_node)
         svg_utils.merge_attribute_less_children(text_node)
         return text_node


### PR DESCRIPTION
## Summary

Implements a new SVG structure optimization that consolidates consecutive `<tspan>` elements with identical attributes. This significantly reduces SVG file size for text with minimal style variation.

## Motivation

When converting text layers from PSD files, psd2svg often generates one `<tspan>` per character. Characters with the same styling can be merged into a single `<tspan>` to reduce file size and improve rendering performance.

## Changes

### New Function: `merge_consecutive_siblings()`

- **Location**: `src/psd2svg/svg_utils.py`
- **Purpose**: Recursively merges consecutive sibling elements with identical tags and attributes
- **Integration**: Added to text conversion pipeline after `merge_common_child_attributes()`

### Algorithm

1. Recursively process all children first (bottom-up)
2. Find sequences of consecutive siblings with:
   - Same tag name
   - Identical attribute sets
   - No child elements
3. Merge text content into first element
4. Remove subsequent elements
5. Remove empty elements (no text or tail)

### Performance Impact

**Example transformation** (Japanese text):

**Before** (6 elements, 426 bytes):
```xml
<text>
    <tspan font-size="18" baseline-shift="-0.36" letter-spacing="0.72">さ</tspan>
    <tspan font-size="18" letter-spacing="0.72">す</tspan>
    <tspan font-size="18" letter-spacing="0.72">だ</tspan>
    <tspan font-size="18" letter-spacing="0.72">け</tspan>
    <tspan font-size="20.85" baseline-shift="-0.36" letter-spacing="0.83">！</tspan>
    <tspan font-size="20.85" baseline-shift="-0.36" letter-spacing="0.83" />
</text>
```

**After** (3 elements, 250 bytes):
```xml
<text>
    <tspan font-size="18" baseline-shift="-0.36" letter-spacing="0.72">さ</tspan>
    <tspan font-size="18" letter-spacing="0.72">すだけ</tspan>
    <tspan font-size="20.85" baseline-shift="-0.36" letter-spacing="0.83">！</tspan>
</text>
```

**Results**:
- 41.3% size reduction
- 50% fewer elements
- Cleaner, more readable SVG

## Test Coverage

Added comprehensive test suite in `tests/test_svg_utils.py`:

- ✅ Merging identical consecutive tspans
- ✅ Stopping at different attributes
- ✅ Removing empty tspans
- ✅ Preserving tail content
- ✅ Skipping elements with children
- ✅ Not merging different tags
- ✅ Recursive processing
- ✅ Edge cases (empty elements, single child)

**All 9 new tests pass**

## Compatibility

- ✅ All existing tests pass (555 passed, 28 skipped, 15 xfailed)
- ✅ Type hints verified with mypy
- ✅ Code style verified with ruff
- ✅ No breaking changes to public API
- ✅ Works with all text conversion modes

## Optimization Pipeline

The text conversion now applies optimizations in this order:

1. `merge_common_child_attributes()` - Hoists common attributes to parent
2. `merge_consecutive_siblings()` - **NEW** - Merges consecutive identical siblings
3. `merge_singleton_children()` - Collapses singleton wrappers
4. `merge_attribute_less_children()` - Removes attribute-less wrappers

This order ensures maximum optimization while maintaining correctness.

## Use Cases

Particularly beneficial for:
- Text with per-character styling changes
- Languages with many characters (CJK, etc.)
- Long text passages with minimal style variation
- Auto-generated SVG from design tools

## Related Work

Complements existing optimizations:
- `merge_common_child_attributes()` - Optimizes all children
- `merge_singleton_children()` - Optimizes single children
- `merge_attribute_less_children()` - Optimizes wrappers

🤖 Generated with [Claude Code](https://claude.com/claude-code)