### PR TITLE
Refactor: Move deepcopy from _handle_images() to public methods

### DIFF
--- a/src/psd2svg/svg_document.py
+++ b/src/psd2svg/svg_document.py
@@ -189,8 +189,11 @@ class SVGDocument:
             optimize: If True, apply SVG optimizations (consolidate defs, etc.).
                 Default is True.
         """
+        # Create a copy to avoid modifying the original SVG
+        svg = deepcopy(self.svg)
+
         svg = self._handle_images(
-            embed_images, image_prefix, image_format, svg_filepath=None
+            svg, embed_images, image_prefix, image_format, svg_filepath=None
         )
 
         if embed_fonts and self.fonts:
@@ -241,8 +244,11 @@ class SVGDocument:
             optimize: If True, apply SVG optimizations (consolidate defs, etc.).
                 Default is True.
         """
+        # Create a copy to avoid modifying the original SVG
+        svg = deepcopy(self.svg)
+
         svg = self._handle_images(
-            embed_images, image_prefix, image_format, svg_filepath=filepath
+            svg, embed_images, image_prefix, image_format, svg_filepath=filepath
         )
 
         if embed_fonts and self.fonts:
@@ -383,6 +389,7 @@ class SVGDocument:
 
     def _handle_images(
         self,
+        svg: ET.Element,
         embed_images: bool,
         image_prefix: str | None,
         image_format: str,
@@ -390,15 +397,21 @@ class SVGDocument:
     ) -> ET.Element:
         """Handle image embedding or saving.
 
+        Modifies the provided SVG element in-place by updating <image> element
+        href attributes to either data URIs or file paths.
+
         Args:
+            svg: SVG element to modify in-place.
             embed_images: If True, embed images as base64 data URIs.
             image_prefix: Path prefix for saving images. If svg_filepath is provided,
                 this is interpreted relative to the SVG file's directory.
             image_format: Image format to use when embedding or saving images.
             svg_filepath: Optional path to the SVG file. When provided, image_prefix
                 is interpreted relative to this file's directory.
+
+        Returns:
+            The modified SVG element (same object as input).
         """
-        svg = deepcopy(self.svg)  # Avoid modifying the original SVG.
         nodes = svg.findall(".//image")
 
         # Validate that all image nodes have IDs and corresponding images exist


### PR DESCRIPTION
## Summary

Move the `copy.deepcopy()` call from `SVGDocument._handle_images()` to the public methods `tostring()` and `save()` to make it explicit that these methods do not modify the original SVG tree in-place.

## Changes

- **Updated `_handle_images()` signature**: Added `svg: ET.Element` as the first parameter
- **Updated `_handle_images()` docstring**: Documents that svg is modified in-place and returns the same object
- **Removed deepcopy from `_handle_images()` body**: No longer creates its own copy
- **Added deepcopy to `tostring()`**: Creates copy before calling `_handle_images()`
- **Added deepcopy to `save()`**: Creates copy before calling `_handle_images()`

## Benefits

1. **Explicit immutability**: The public methods now clearly show that they create a copy before modification
2. **Consistency**: Aligns with the existing `_insert_css_fontface()` pattern which also accepts svg as a parameter
3. **Better separation of concerns**: Public methods handle defensive copying; private methods handle mutations
4. **Clearer API**: Makes it obvious that `_handle_images()` mutates the svg parameter in-place

## Testing

- ✅ All 36 tests in `test_svg_document.py` pass
- ✅ Type checking passes (mypy)
- ✅ Linting passes (ruff)
- ✅ No behavioral changes - identical functionality from public API perspective

## Test Plan

```bash
uv run pytest tests/test_svg_document.py -v
uv run mypy src/psd2svg/svg_document.py
uv run ruff check src/psd2svg/svg_document.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)