### PR TITLE
Fix fontconfig API usage in charset-based font resolution

### DIFF
--- a/src/psd2svg/core/font_utils.py
+++ b/src/psd2svg/core/font_utils.py
@@ -285,24 +285,15 @@ class FontInfo:
                 # Create CharSet from codepoints
                 charset = fontconfig.CharSet.from_codepoints(sorted(charset_codepoints))
 
-                # Try using match() with properties first
-                try:
-                    match = fontconfig.match(
-                        pattern=f":postscriptname={self.postscript_name}",
-                        select=("file", "family", "style", "weight"),
-                        properties={"charset": charset},
-                    )
-                except TypeError:
-                    # Fall back to list() if match() doesn't support properties
-                    logger.debug(
-                        "fontconfig.match() doesn't support properties, "
-                        "falling back to list()"
-                    )
-                    results = fontconfig.list(
-                        pattern=f":postscriptname={self.postscript_name}",
-                        properties={"charset": charset},
-                    )
-                    match = results[0] if results else None
+                # Use properties dict for charset-based matching
+                # Cannot specify both 'pattern' and 'properties' in fontconfig API
+                match = fontconfig.match(
+                    properties={
+                        "postscriptname": self.postscript_name,
+                        "charset": charset,
+                    },
+                    select=("file", "family", "style", "weight"),
+                )
             else:
                 # Standard PostScript name matching (existing behavior)
                 match = fontconfig.match(


### PR DESCRIPTION
## Summary

Fixed incorrect fontconfig API usage that was causing a warning during charset-based font resolution.

## Problem

The code was incorrectly passing both `pattern` and `properties` parameters to `fontconfig.match()`:

```python
match = fontconfig.match(
    pattern=f":postscriptname={self.postscript_name}",
    select=("file", "family", "style", "weight"),
    properties={"charset": charset},  # ❌ Cannot use both!
)
```

This caused the warning:
```
WARNING:psd2svg.core.font_utils:Charset-based resolution failed for 'ArialMT': 
Cannot specify both 'pattern' and 'properties'. Falling back to name-only matching
```

## Solution

Updated the charset-based matching to use only the `properties` dict:

```python
match = fontconfig.match(
    properties={
        "postscriptname": self.postscript_name,
        "charset": charset,
    },
    select=("file", "family", "style", "weight"),
)
```

Also removed the unnecessary try-except fallback to `fontconfig.list()` since the issue was with the API usage, not function support.

## Testing

- All 173 font-related tests pass
- Type checking and linting pass
- Warning no longer appears during font resolution

🤖 Generated with [Claude Code](https://claude.com/claude-code)