### PR TITLE
Fix: Filter control characters from text for charset-based font matching

### DIFF
--- a/src/psd2svg/font_subsetting.py
+++ b/src/psd2svg/font_subsetting.py
@@ -295,10 +295,14 @@ def _extract_text_content(element: ET.Element) -> str:
     # Decode HTML/XML entities
     decoded_text = html.unescape(raw_text)
 
-    # Filter out control characters (codepoints 0-31, below space which is 32)
+    # Filter out control characters (C0: 0-31, DEL: 127, C1: 128-159)
     # These are not rendered in SVG text and cause incorrect font matching
     # (e.g., newline causes Arial to be substituted with LastResort on macOS)
-    decoded_text = "".join(char for char in decoded_text if ord(char) >= 32)
+    decoded_text = "".join(
+        char
+        for char in decoded_text
+        if ord(char) >= 32 and not (127 <= ord(char) <= 159)
+    )
 
     return decoded_text
 

--- a/src/psd2svg/svg_utils.py
+++ b/src/psd2svg/svg_utils.py
@@ -1017,10 +1017,12 @@ def extract_text_characters(element: ET.Element) -> str:
     if element.tail:
         result += html.unescape(element.tail)
 
-    # Filter out control characters (codepoints 0-31, below space which is 32)
+    # Filter out control characters (C0: 0-31, DEL: 127, C1: 128-159)
     # These are not rendered in SVG text and cause incorrect font matching
     # (e.g., newline causes Arial to be substituted with LastResort on macOS)
-    result = "".join(char for char in result if ord(char) >= 32)
+    result = "".join(
+        char for char in result if ord(char) >= 32 and not (127 <= ord(char) <= 159)
+    )
 
     return result
 

--- a/tests/test_font_subsetting.py
+++ b/tests/test_font_subsetting.py
@@ -441,6 +441,14 @@ class TestHelperFunctions:
         assert "\n" not in _extract_text_content(elem)
         assert "\t" not in _extract_text_content(elem)
 
+        # Text with DEL and C1 controls (should be filtered)
+        elem = ET.fromstring("<text>A\x7fB\x80C</text>")  # DEL (127), C1 (128)
+        assert _extract_text_content(elem) == "ABC"
+
+        # Text with only control characters (should return empty)
+        elem = ET.fromstring("<text>\n\t\r</text>")
+        assert _extract_text_content(elem) == ""
+
         # Text with only spaces (should be preserved)
         elem = ET.fromstring("<text>Hello World</text>")
         assert _extract_text_content(elem) == "Hello World"


### PR DESCRIPTION
## Summary

Fixed incorrect font substitution (Arial → LastResort) when using charset-based font matching with text containing control characters (newlines, tabs, etc.).

## Problem

When text in SVG elements contained control characters (like `\n` with codepoint 10), the charset-based font resolution would fail:

```
INFO:psd2svg.core.font_utils:Font substitution: 'Arial' → '.LastResort' 
(file: /System/Library/Fonts/LastResort.otf)
```

**Root cause**: When fontconfig performs charset-based matching and the charset includes control characters, it returns LastResort font because standard fonts like Arial don't have glyphs for these characters. LastResort is a special macOS font that provides placeholder glyphs for ALL Unicode codepoints.

## Debugging Journey

1. Discovered the issue only occurred with PlaywrightRasterizer (which uses charset-based matching), not ResvgRasterizer
2. Found that codepoints included `[10, 32, 73, 76, 101, 109, 111, 112, 114, 115, 117]` (note the `10` = newline)
3. Tested fontconfig directly:
   - With newline (10): Returns `.LastResort`
   - Without newline: Returns `Arial` correctly
   - With DEL (127): Returns `AppleGothic` instead of `Arial`

## Solution

Filter out control characters from text extraction since:
- They are not rendered in SVG text elements
- They should not be part of font matching criteria
- Standard fonts don't have glyphs for them

**Filtered ranges**:
- **C0 controls** (0-31): Includes newline, tab, carriage return, etc.
- **DEL** (127): Delete character
- **C1 controls** (128-159): Additional control characters

**Modified functions**:
- `svg_utils.extract_text_characters()` - Used for font fallback chains
- `font_subsetting._extract_text_content()` - Used for font subsetting

**Edge case handling**:
- If all characters are filtered (text contains only control characters), the code gracefully falls back to name-only font matching
- Existing check at line 600 of svg_document.py handles empty charset

## Testing

- Added test cases for:
  - C0 control characters (newline, tab)
  - DEL and C1 control characters
  - Empty text after filtering
- All existing tests pass
- Verified Arial resolves correctly with the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)