### PR TITLE
Refactor font subsetting to use set[int] instead of set[str]

### DIFF
--- a/src/psd2svg/font_subsetting.py
+++ b/src/psd2svg/font_subsetting.py
@@ -69,17 +69,17 @@ def extract_used_unicode(svg_tree: ET.Element) -> dict[str, set[str]]:
 def subset_font(
     input_path: str,
     output_format: str,
-    unicode_chars: set[str],
+    unicode_codepoints: set[int],
 ) -> bytes:
-    """Subset a font file to include only specified Unicode characters.
+    """Subset a font file to include only specified Unicode codepoints.
 
     This function uses fontTools (pyftsubset) to create a minimal font file
-    containing only the glyphs needed for the specified characters.
+    containing only the glyphs needed for the specified codepoints.
 
     Args:
         input_path: Path to input font file (TTF/OTF).
         output_format: Output format - "ttf", "otf", or "woff2".
-        unicode_chars: Set of Unicode characters to include in the subset.
+        unicode_codepoints: Set of Unicode codepoints (integers) to include in the subset.
 
     Returns:
         Subset font file as bytes.
@@ -89,8 +89,8 @@ def subset_font(
         Exception: If subsetting fails (invalid font, I/O error, etc.).
 
     Example:
-        >>> chars = {"A", "B", "C", "あ"}
-        >>> font_bytes = subset_font("/usr/share/fonts/arial.ttf", "woff2", chars)
+        >>> codepoints = {0x41, 0x42, 0x43, 0x3042}  # A, B, C, あ
+        >>> font_bytes = subset_font("/usr/share/fonts/arial.ttf", "woff2", codepoints)
         >>> len(font_bytes)  # Much smaller than original
         8432
     """
@@ -100,17 +100,17 @@ def subset_font(
             f"Supported formats: ttf, otf, woff2"
         )
 
-    if not unicode_chars:
+    if not unicode_codepoints:
         logger.warning(
-            "No Unicode characters provided for subsetting, using all glyphs"
+            "No Unicode codepoints provided for subsetting, using all glyphs"
         )
 
-    # Convert characters to Unicode code points
-    unicodes = _chars_to_unicode_list(unicode_chars)
+    # Convert to sorted list for fontTools
+    unicodes = sorted(unicode_codepoints)
 
     logger.debug(
         f"Subsetting font: {input_path} -> {output_format} "
-        f"({len(unicode_chars)} char(s), {len(unicodes)} codepoint(s))"
+        f"({len(unicode_codepoints)} codepoint(s))"
     )
 
     try:

--- a/src/psd2svg/svg_document.py
+++ b/src/psd2svg/svg_document.py
@@ -812,14 +812,14 @@ class SVGDocument:
             try:
                 # Generate CSS source based on mode
                 if use_data_uri:
-                    # Prepare subset characters from FontInfo.charset (convert codepoints to chars)
-                    subset_chars: set[str] | None = None
+                    # Prepare subset codepoints from FontInfo.charset
+                    subset_codepoints: set[int] | None = None
                     if subset_fonts and resolved_font.charset:
-                        subset_chars = {chr(cp) for cp in resolved_font.charset}
+                        subset_codepoints = resolved_font.charset
                     css_source = font_utils.encode_font_with_options(
                         font_path=resolved_font.file,
                         cache=self._font_data_cache,
-                        subset_chars=subset_chars,
+                        subset_codepoints=subset_codepoints,
                         font_format=font_format,
                     )
                 else:

--- a/tests/test_font_subsetting.py
+++ b/tests/test_font_subsetting.py
@@ -155,10 +155,10 @@ class TestFontSubsetting:
         if not font_info:
             pytest.skip("Arial font not available")
 
-        # Subset with just a few characters
-        chars = {"A", "B", "C"}
+        # Subset with just a few characters (as codepoints)
+        codepoints = {0x41, 0x42, 0x43}  # A, B, C
         try:
-            font_bytes = subset_font(font_info.file, "ttf", chars)
+            font_bytes = subset_font(font_info.file, "ttf", codepoints)
         except (KeyError, Exception) as e:
             pytest.skip(f"Font subsetting failed (corrupt font file?): {e}")
 
@@ -176,9 +176,9 @@ class TestFontSubsetting:
         if not font_info:
             pytest.skip("Arial font not available")
 
-        chars = {"H", "e", "l", "o", "W", "r", "d"}
+        codepoints = {0x48, 0x65, 0x6C, 0x6F, 0x57, 0x72, 0x64}  # H, e, l, o, W, r, d
         try:
-            font_bytes = subset_font(font_info.file, "woff2", chars)
+            font_bytes = subset_font(font_info.file, "woff2", codepoints)
         except (KeyError, Exception) as e:
             pytest.skip(f"Font subsetting failed (corrupt font file?): {e}")
 
@@ -197,7 +197,9 @@ class TestFontSubsetting:
 
         # Small subset (3 chars)
         try:
-            small_subset = subset_font(font_info.file, "ttf", {"A", "B", "C"})
+            small_subset = subset_font(
+                font_info.file, "ttf", {0x41, 0x42, 0x43}
+            )  # A, B, C
         except (KeyError, Exception) as e:
             pytest.skip(f"Font subsetting failed (corrupt font file?): {e}")
 
@@ -206,7 +208,7 @@ class TestFontSubsetting:
             large_subset = subset_font(
                 font_info.file,
                 "ttf",
-                set("ABCDEFGHIJKLMNOPQRSTUVWXYZ"),
+                {ord(c) for c in "ABCDEFGHIJKLMNOPQRSTUVWXYZ"},
             )
         except (KeyError, Exception) as e:
             pytest.skip(f"Font subsetting failed (corrupt font file?): {e}")
@@ -222,7 +224,7 @@ class TestFontSubsetting:
         """Test error with unsupported font format."""
 
         with pytest.raises(ValueError, match="Unsupported font format"):
-            subset_font("/fake/path.ttf", "invalid", {"A"})
+            subset_font("/fake/path.ttf", "invalid", {0x41})  # A
 
     @pytest.mark.requires_noto_sans_jp
     def test_subset_font_unicode_chars(self) -> None:
@@ -232,10 +234,10 @@ class TestFontSubsetting:
         if not font_info:
             pytest.skip("Noto Sans JP font not available")
 
-        # Subset with Japanese characters
-        chars = {"こ", "ん", "に", "ち", "は"}
+        # Subset with Japanese characters (as codepoints)
+        codepoints = {0x3053, 0x3093, 0x306B, 0x3061, 0x306F}  # こ, ん, に, ち, は
         try:
-            font_bytes = subset_font(font_info.file, "woff2", chars)
+            font_bytes = subset_font(font_info.file, "woff2", codepoints)
         except (KeyError, Exception) as e:
             pytest.skip(f"Font subsetting failed (corrupt font file?): {e}")
 


### PR DESCRIPTION
## Summary

Refactor the font subsetting call chain to use `set[int]` (Unicode codepoints) consistently instead of converting between `set[str]` (characters) and `set[int]` (codepoints).

This eliminates redundant type conversions and simplifies the code:
- **Before**: `set[int]` (stored in FontInfo.charset) → `set[str]` (line 818) → `list[int]` (fontTools)
- **After**: `set[int]` (stored in FontInfo.charset) → `list[int]` (fontTools) directly

## Changes

### API Updates
- [`subset_font()`](src/psd2svg/font_subsetting.py#L69): Changed parameter from `unicode_chars: set[str]` to `unicode_codepoints: set[int]`
- [`encode_font_with_options()`](src/psd2svg/core/font_utils.py#L908): Changed parameter from `subset_chars: set[str]` to `subset_codepoints: set[int]`
- [`create_charset_codepoints()`](src/psd2svg/core/font_utils.py#L976): Inlined conversion logic, removed dependency on `_chars_to_unicode_list()`

### Implementation
- [svg_document.py:816-818](src/psd2svg/svg_document.py#L816-L818): Removed redundant `chr(cp)` conversion, now directly assigns `resolved_font.charset`
- [test_font_subsetting.py](tests/test_font_subsetting.py): Updated all test cases to use codepoints (e.g., `{0x41, 0x42, 0x43}` instead of `{"A", "B", "C"}`)

## Benefits

1. **Performance**: Eliminates redundant conversions between characters and codepoints
2. **Type safety**: Clearer semantics (codepoints are fundamentally integers)
3. **Simplicity**: Direct assignment instead of set comprehensions
4. **Consistency**: Aligns with how `FontInfo.charset` already stores data

## Backward Compatibility

- ✅ No external API changes (subsetting functions are internal)
- ✅ `extract_used_unicode()` remains unchanged (returns `set[str]` as public API)
- ✅ `_chars_to_unicode_list()` kept for backward compatibility (but no longer used internally)

## Testing

- ✅ All tests pass (625 passed, 15 skipped, 15 xfailed)
- ✅ Type checking passes (`mypy`)
- ✅ Linting passes (`ruff`)
- ✅ No functional changes - purely internal refactoring

## Test plan

- [x] Run full test suite
- [x] Type checking with mypy
- [x] Linting with ruff
- [x] Manual verification: font subsetting still works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)