### PR TITLE
Refactor: Make resolved_fonts_map parameter required in _insert_css_fontface

### DIFF
--- a/src/psd2svg/svg_document.py
+++ b/src/psd2svg/svg_document.py
@@ -855,7 +855,7 @@ class SVGDocument:
         subset_fonts: bool,
         font_format: str,
         use_data_uri: bool,
-        resolved_fonts_map: dict[str, FontInfo] | None = None,
+        resolved_fonts_map: dict[str, FontInfo],
     ) -> None:
         """Insert CSS @font-face rules in a <style> element.
 
@@ -870,10 +870,9 @@ class SVGDocument:
             font_format: Font format for encoding (only applicable for data URIs).
             use_data_uri: If True, use data URIs; if False, use file:// URLs.
             resolved_fonts_map: Pre-resolved fonts from _resolve_and_collect_fonts().
-                Must not be None when this method is called.
         """
         if not resolved_fonts_map:
-            logger.warning("No resolved fonts provided; skipping font embedding")
+            logger.warning("No resolved fonts found; skipping font embedding")
             return
 
         # Use pre-resolved fonts directly - NO re-resolution needed

--- a/tests/test_svg_document.py
+++ b/tests/test_svg_document.py
@@ -448,7 +448,7 @@ class TestSVGDocumentEmbedFonts:
         assert "<style>" not in result
 
         # Should log warning about no fonts embedded (font resolution returned None)
-        assert "No resolved fonts provided; skipping font embedding" in caplog.text
+        assert "No resolved fonts found; skipping font embedding" in caplog.text
 
     @patch("psd2svg.core.font_utils.encode_font_data_uri")
     @patch("psd2svg.core.font_utils.FontInfo.find_with_files")


### PR DESCRIPTION
## Summary

This PR fixes a type signature inconsistency in the `_insert_css_fontface` method where the `resolved_fonts_map` parameter was marked as optional (`| None` with default value) but the implementation and usage pattern required it to always be provided.

## Changes

- Remove `| None` from `resolved_fonts_map` type annotation
- Remove default value `= None` from parameter
- Update warning message to "No resolved fonts found" for clarity
- Update test assertion to match new warning message
- Update docstring to remove misleading "Must not be None" statement

## Rationale

The method is always called with a non-None value from `_resolve_and_collect_fonts()` at [svg_document.py:193-199](https://github.com/kyamagu/psd2svg/blob/main/src/psd2svg/svg_document.py#L193-L199):

```python
if embed_fonts:
    resolved_fonts_map = self._resolve_and_collect_fonts(svg)
    self._insert_css_fontface(
        svg,
        subset_fonts=subset_fonts,
        font_format=font_format,
        use_data_uri=use_data_uri_for_fonts,
        resolved_fonts_map=resolved_fonts_map,
    )
```

The optional type annotation was misleading and inconsistent with actual usage. Making it required:
1. Makes the type signature match the actual contract
2. Improves type safety
3. Prevents potential misuse
4. Removes confusion from the docstring

## Test Plan

- All existing tests pass (625 passed, 15 skipped, 15 xfailed)
- Type checking passes with mypy
- Linting passes with ruff

🤖 Generated with [Claude Code](https://claude.com/claude-code)