### PR TITLE
Refactor create_charset_codepoints to not return None

### DIFF
--- a/src/psd2svg/core/font_utils.py
+++ b/src/psd2svg/core/font_utils.py
@@ -234,16 +234,17 @@ class FontInfo:
         Args:
             postscriptname: PostScript name of the font.
             charset_codepoints: Optional set of Unicode codepoints for charset matching.
+                               Empty sets are treated as None (no charset matching).
 
         Returns:
             fontconfig match result dict with keys: file, family, style, weight.
             None if no match found.
 
         Raises:
-            Exception: If fontconfig matching fails and charset_codepoints is None.
+            Exception: If fontconfig matching fails and charset_codepoints is None or empty.
         """
         try:
-            if charset_codepoints is not None:
+            if charset_codepoints:
                 # Use charset-based matching
                 logger.debug(
                     f"Using charset with {len(charset_codepoints)} codepoints "
@@ -266,7 +267,7 @@ class FontInfo:
             return match  # type: ignore
         except Exception as e:
             # Graceful degradation: fall back to name-only matching
-            if charset_codepoints is not None:
+            if charset_codepoints:
                 logger.warning(
                     f"Charset-based matching failed for '{postscriptname}': {e}. "
                     "Falling back to name-only matching"
@@ -292,18 +293,19 @@ class FontInfo:
         Args:
             postscriptname: PostScript name of the font.
             charset_codepoints: Optional set of Unicode codepoints for charset matching.
+                               Empty sets are treated as None (no charset matching).
 
         Returns:
             Windows font resolver match result dict with keys: file, family, style, weight.
             None if no match found.
 
         Raises:
-            Exception: If Windows matching fails and charset_codepoints is None.
+            Exception: If Windows matching fails and charset_codepoints is None or empty.
         """
         resolver = _windows_fonts.get_windows_font_resolver()  # type: ignore[attr-defined]
 
         try:
-            if charset_codepoints is not None:
+            if charset_codepoints:
                 # Use charset-based matching
                 logger.debug(
                     f"Using charset with {len(charset_codepoints)} codepoints "
@@ -316,7 +318,7 @@ class FontInfo:
             return match  # type: ignore
         except Exception as e:
             # Graceful degradation: fall back to name-only matching
-            if charset_codepoints is not None:
+            if charset_codepoints:
                 logger.warning(
                     f"Charset-based matching failed for '{postscriptname}': {e}. "
                     "Falling back to name-only matching"
@@ -336,10 +338,11 @@ class FontInfo:
         Args:
             postscriptname: PostScript name of the font.
             charset_codepoints: Optional set of Unicode codepoints for charset matching.
+                               Empty sets are treated as None (no charset matching).
 
         Returns:
-            FontInfo object if found, None otherwise. If charset_codepoints is provided,
-            the returned FontInfo will have charset populated for later resolution.
+            FontInfo object if found, None otherwise. If charset_codepoints is provided
+            and non-empty, the returned FontInfo will have charset populated for later resolution.
         """
         logger.debug(
             f"Font '{postscriptname}' not in static mapping, trying fontconfig..."
@@ -375,10 +378,11 @@ class FontInfo:
         Args:
             postscriptname: PostScript name of the font.
             charset_codepoints: Optional set of Unicode codepoints for charset matching.
+                               Empty sets are treated as None (no charset matching).
 
         Returns:
-            FontInfo object if found, None otherwise. If charset_codepoints is provided,
-            the returned FontInfo will have charset populated for later resolution.
+            FontInfo object if found, None otherwise. If charset_codepoints is provided
+            and non-empty, the returned FontInfo will have charset populated for later resolution.
         """
         logger.debug(
             f"Font '{postscriptname}' not in static mapping, trying Windows registry..."
@@ -429,7 +433,8 @@ class FontInfo:
                          {"PostScriptName": {"family": str, "style": str, "weight": float}}
             charset_codepoints: Optional set of Unicode codepoints for charset-based
                                font matching. Only used when disable_static_mapping=True
-                               (platform resolution). Default: None.
+                               (platform resolution). Empty sets are treated as None
+                               (no charset matching). Default: None.
             disable_static_mapping: If True, use find_with_files(); if False, use find_static().
                                    Default: False.
 
@@ -550,6 +555,7 @@ class FontInfo:
                          to platform resolution.
             charset_codepoints: Optional Unicode codepoints for charset-based matching.
                                Prioritizes fonts with better glyph coverage.
+                               Empty sets are treated as None (no charset matching).
 
         Returns:
             FontInfo with non-empty file path, or None if not found. File path is

--- a/src/psd2svg/svg_document.py
+++ b/src/psd2svg/svg_document.py
@@ -726,10 +726,10 @@ class SVGDocument:
             # Step 2: Resolve PostScript name → family name with platform resolution
             try:
                 # Single resolution call per font (uses platform-specific resolution)
-                # Convert empty set to None to skip charset-based matching
+                # Empty sets are automatically treated as None (no charset matching)
                 resolved_font = FontInfo.find_with_files(
                     ps_name,
-                    charset_codepoints=charset_codepoints or None,
+                    charset_codepoints=charset_codepoints,
                 )
             except Exception as e:
                 logger.warning(


### PR DESCRIPTION
## Summary

Refactored `font_utils.create_charset_codepoints()` and `SVGDocument._extract_font_elements_and_charset()` to not return `None`, and updated charset handling throughout the font matching system:

**1. Eliminated `None` returns:**
- Changed `create_charset_codepoints()` return type from `set[int] | None` to `set[int]`
- Always returns a set (possibly empty) instead of `None`
- Updated `_extract_font_elements_and_charset()` return type to `tuple[list[ET.Element], set[int]]`

**2. Proper empty set handling:**
- Changed charset checks from `if charset_codepoints is not None:` to `if charset_codepoints:` in `_match_fontconfig()` and `_match_windows()`
- Empty sets now automatically treated as `None` (skip charset-based matching)
- This maintains the correct semantic: empty charset = no characters to match = skip charset matching

**3. Simplified caller code:**
- Removed `or None` conversion in `svg_document.py` since empty sets are now handled correctly by font matching functions
- Functions are now robust regardless of whether they receive `None` or empty `set()`

**4. Updated documentation:**
- All docstrings now document that empty sets are treated as `None` (no charset matching)

## Benefits

- **Simpler API**: Functions always return sets, eliminating `None` checks in some contexts
- **Correct semantics**: Empty charset correctly skips charset-based matching (same as `None`)
- **Robust behavior**: Functions handle both `None` and empty sets correctly
- **Better type safety**: Clearer return types

## Test plan

- [x] All existing tests pass (615 passed, 15 skipped, 15 xfailed)
- [x] Type checking passes (mypy)
- [x] Linting passes (ruff)
- [x] Code formatting passes (ruff format)
- [x] Manual verification: empty sets correctly skip charset-based matching

🤖 Generated with [Claude Code](https://claude.com/claude-code)