### PR TITLE
Refactor: Rename FontInfo.find_static() to lookup_static()

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -71,7 +71,7 @@ psd2svg uses a **two-phase approach** to optimize performance:
 
 psd2svg provides two distinct resolution methods optimized for different use cases:
 
-**`FontInfo.find_static()`** - For CSS family names only:
+**`FontInfo.lookup_static()`** - For font metadata lookup only:
 
 - Resolution chain: Custom mapping → Static mapping (572 fonts) → None
 - Returns family name, style, and weight (no file path)
@@ -91,7 +91,7 @@ psd2svg provides two distinct resolution methods optimized for different use cas
 
 **`FontInfo.find()`** - Backward-compatible wrapper:
 
-- Delegates to `find_static()` by default (safe behavior)
+- Delegates to `lookup_static()` by default (safe behavior)
 - Use `disable_static_mapping=True` to delegate to `resolve()`
 - Maintained for backward compatibility; prefer explicit methods in new code
 
@@ -123,9 +123,9 @@ When resolving fonts, psd2svg analyzes actual text characters for better matchin
 #### Key API Methods
 
 - `TypeSetting.get_postscript_name()`: Extract PostScript name from PSD
-- `FontInfo.find_static()`: Resolve PostScript name to CSS family (no platform queries)
+- `FontInfo.lookup_static()`: Lookup PostScript name to get font metadata (no platform queries)
 - `FontInfo.resolve()`: Resolve PostScript name to font file with platform resolution
-- `FontInfo.find()`: Backward-compatible wrapper (delegates to `find_static()` or `resolve()`)
+- `FontInfo.find()`: Backward-compatible wrapper (delegates to `lookup_static()` or `resolve()`)
 - SVG tree is single source of truth for fonts (no separate font list maintained)
 
 ## Architecture Overview

--- a/src/psd2svg/core/font_utils.py
+++ b/src/psd2svg/core/font_utils.py
@@ -84,11 +84,11 @@ class FontInfo:
 
         Example:
             >>> # Font from static mapping (not resolved)
-            >>> font_info = FontInfo.find_static('ArialMT')
+            >>> font_info = FontInfo.lookup_static('ArialMT')
             >>> font_info.is_resolved()
             False
             >>> # Font with file path (resolved)
-            >>> resolved = FontInfo.find_with_files('ArialMT')
+            >>> resolved = FontInfo.resolve('ArialMT')
             >>> if resolved:
             ...     resolved.is_resolved()
             True
@@ -420,12 +420,12 @@ class FontInfo:
 
         This method is kept for backward compatibility. New code should use the more
         explicit methods:
-        - find_static() for CSS family names (embed_fonts=False scenarios)
-        - find_with_files() for font embedding (embed_fonts=True scenarios)
+        - lookup_static() for CSS family names (embed_fonts=False scenarios)
+        - resolve() for font embedding (embed_fonts=True scenarios)
 
         This wrapper delegates to the appropriate method based on disable_static_mapping:
-        - If disable_static_mapping=False: Uses find_static() (name resolution only)
-        - If disable_static_mapping=True: Uses find_with_files() (with file paths)
+        - If disable_static_mapping=False: Uses lookup_static() (name resolution only)
+        - If disable_static_mapping=True: Uses resolve() (with file paths)
 
         Args:
             postscriptname: PostScript name of the font (e.g., "ArialMT").
@@ -445,7 +445,7 @@ class FontInfo:
             >>> # Standard resolution (static mapping)
             >>> font = FontInfo.find('ArialMT')
             >>> # Is equivalent to:
-            >>> font = FontInfo.find_static('ArialMT')
+            >>> font = FontInfo.lookup_static('ArialMT')
             >>>
             >>> # Font embedding resolution (platform-specific)
             >>> font = FontInfo.find('ArialMT', disable_static_mapping=True)
@@ -455,14 +455,14 @@ class FontInfo:
         if disable_static_mapping:
             return FontInfo.resolve(postscriptname, font_mapping, charset_codepoints)
         else:
-            return FontInfo.find_static(postscriptname, font_mapping)
+            return FontInfo.lookup_static(postscriptname, font_mapping)
 
     @staticmethod
-    def find_static(
+    def lookup_static(
         postscriptname: str,
         font_mapping: dict[str, dict[str, float | str]] | None = None,
     ) -> Self | None:
-        """Find font using custom and static mappings only (no platform resolution).
+        """Lookup font metadata using custom and static mappings only (no platform resolution).
 
         This method resolves PostScript names to CSS font families without accessing
         system fonts. It is suitable for SVG generation when embed_fonts=False, where
@@ -486,12 +486,12 @@ class FontInfo:
 
         Example:
             >>> # Resolve common font (found in static mapping)
-            >>> font = FontInfo.find_static('ArialMT')
+            >>> font = FontInfo.lookup_static('ArialMT')
             >>> assert font.family == 'Arial'
             >>> assert font.file == ''  # No file path
             >>>
             >>> # Resolve uncommon font (not in static mapping)
-            >>> font = FontInfo.find_static('UnknownFont')
+            >>> font = FontInfo.lookup_static('UnknownFont')
             >>> assert font is None  # Preserves PostScript name in SVG
         """
         # 1. Check custom mapping first

--- a/src/psd2svg/svg_document.py
+++ b/src/psd2svg/svg_document.py
@@ -644,7 +644,7 @@ class SVGDocument:
 
         for ps_name in postscript_names:
             # Resolve using static mapping only (no platform queries)
-            resolved_font = FontInfo.find_static(ps_name)
+            resolved_font = FontInfo.lookup_static(ps_name)
 
             if resolved_font is None:
                 # Font not in static mapping - keep PostScript name

--- a/tests/test_font_utils.py
+++ b/tests/test_font_utils.py
@@ -274,7 +274,7 @@ class TestFontInfoFind:
     @pytest.mark.skipif(not HAS_FONTCONFIG, reason="Requires fontconfig (Linux/macOS)")
     @pytest.mark.skipif(not HAS_FONTCONFIG, reason="Requires fontconfig (Linux/macOS)")
     @patch("psd2svg.core.font_utils.fontconfig.match")
-    def test_find_static_mapping_priority(self, mock_match: MagicMock) -> None:
+    def test_lookup_static_mapping_priority(self, mock_match: MagicMock) -> None:
         """Test that static mapping is used first, fontconfig not called."""
         # ArialMT is in the static mapping, so fontconfig should NOT be called
         font = FontInfo.find("ArialMT")


### PR DESCRIPTION
## Summary

Renamed `FontInfo.find_static()` to `FontInfo.lookup_static()` to better reflect its purpose and behavior.

## Rationale

The original name `find_static()` was misleading because:
- The method doesn't "find" or search for fonts on the system
- It performs a deterministic **lookup** operation using static dictionaries
- It returns a complete `FontInfo` object with family, style, and weight metadata (not just family name)
- The log messages already use "Resolved" terminology, not "Found"

The new name `lookup_static()` better conveys:
- Dictionary-based lookup operation (not discovery/search)
- Returns structured metadata (FontInfo object with family/style/weight)
- Contrasts clearly with `resolve()` which does platform-specific file resolution

## Changes

**Code:**
- Renamed method definition in `src/psd2svg/core/font_utils.py`
- Updated all call sites and internal references
- Updated `FontInfo.find()` wrapper to call `lookup_static()`
- Updated test method name for consistency

**Documentation:**
- Updated `CLAUDE.md` "Resolution Methods" section
- Updated "Key API Methods" section
- Updated all docstring examples

## Testing

✅ All checks passed:
- Formatting: `ruff format` - 54 files unchanged
- Linting: `ruff check` - All checks passed
- Type checking: `mypy` - No issues found
- Tests: `pytest` - 620 passed, 15 skipped, 15 xfailed

## Breaking Change

This is a breaking change for any code directly calling `FontInfo.find_static()`. Users should update to:
- `FontInfo.lookup_static()` for the new method name
- Or continue using `FontInfo.find()` wrapper for backward compatibility

🤖 Generated with [Claude Code](https://claude.com/claude-code)