### PR TITLE
Add font weight and style inference from PostScript name suffixes

### DIFF
--- a/src/psd2svg/core/font_utils.py
+++ b/src/psd2svg/core/font_utils.py
@@ -62,10 +62,13 @@ WEIGHT_SUFFIXES: dict[str, tuple[str, float]] = {
     "Ultra": ("Ultra", 210.0),
     "Roman": ("Roman", 80.0),  # Times-Roman
     "MT": ("Regular", 80.0),  # Mac Type suffix
-    # Abbreviated suffixes (common in Japanese fonts like Rodin family)
+    # Abbreviated suffixes (common in Japanese fonts)
     "B": ("Bold", 200.0),  # Bold abbreviation
-    "DB": ("SemiBold", 180.0),  # DemiBold abbreviation
-    "EB": ("ExtraBold", 205.0),  # ExtraBold abbreviation
+    "DB": ("SemiBold", 180.0),  # DemiBold abbreviation (short)
+    "DeBold": ("SemiBold", 180.0),  # DemiBold abbreviation (medium)
+    "EB": ("ExtraBold", 205.0),  # ExtraBold abbreviation (short)
+    "ExBold": ("ExtraBold", 205.0),  # ExtraBold abbreviation (medium)
+    "ExLight": ("ExtraLight", 40.0),  # ExtraLight abbreviation
     "UB": ("Ultra", 210.0),  # UltraBold abbreviation
 }
 

--- a/tests/test_font_mapping.py
+++ b/tests/test_font_mapping.py
@@ -678,13 +678,16 @@ class TestSuffixParsing:
         assert font.get_css_weight() == 700  # Bold = 700 in CSS
 
     def test_parse_abbreviated_suffixes(self) -> None:
-        """Test suffix parsing for abbreviated suffixes (B, DB, EB, UB)."""
+        """Test suffix parsing for abbreviated suffixes (B, DB, EB, UB, DeBold, ExBold, ExLight)."""
         test_cases = [
             ("RodinCattleyaPro-B", "Bold", 200.0),
-            ("RodinCattleyaPro-DB", "SemiBold", 180.0),  # DemiBold
-            ("RodinCattleyaPro-EB", "ExtraBold", 205.0),
+            ("RodinCattleyaPro-DB", "SemiBold", 180.0),  # DemiBold (short)
+            ("RodinCattleyaPro-EB", "ExtraBold", 205.0),  # ExtraBold (short)
             ("RodinCattleyaPro-UB", "Ultra", 210.0),  # UltraBold
             ("RowdyStd-EB", "ExtraBold", 205.0),
+            ("PAotoGothicStdN-DeBold", "SemiBold", 180.0),  # DemiBold (medium)
+            ("PAotoGothicStdN-ExBold", "ExtraBold", 205.0),  # ExtraBold (medium)
+            ("PAotoGothicStdN-ExLight", "ExtraLight", 40.0),  # ExtraLight abbreviation
         ]
 
         for name, expected_style, expected_weight in test_cases:


### PR DESCRIPTION
## Summary

Adds fallback mechanism to infer font-weight and font-style from PostScript name suffixes when `FontInfo.lookup_static()` fails to find an exact match in the static mapping. This provides reasonable fallback behavior for fonts not in the 572-entry static mapping.

## Motivation

PSD files often contain fonts with PostScript names not in the static mapping. When these fonts can't be resolved, they remain as PostScript names in the SVG output, causing incorrect rendering. This feature parses common suffix patterns to extract font metadata, improving fallback rendering quality.

## Key Features

### 1. Two-Phase Parsing Algorithm
- **Phase 1 (Hyphenated)**: Primary approach for patterns like `Font-Bold`, `mplus-1c-bold`
- **Phase 2 (CamelCase)**: Fallback for patterns like `RobotoBold` (with whitelist to prevent false positives)

### 2. Comprehensive Suffix Support
- **Standard weights**: Thin, ExtraLight, Light, Regular, Medium, SemiBold, Bold, ExtraBold, Black, Heavy, Ultra
- **Abbreviated forms**: B, DB (DemiBold), DeBold, EB (ExtraBold), ExBold, ExLight, UB (UltraBold)
- **Japanese W-notation**: Complete W0-W9 range (Hiragino fonts)
- **Compound styles**: BoldItalic, LightItalic, BoldOblique, etc.
- **Alternative spellings**: Semibold/SemiBold, Extrabold/ExtraBold, etc.

### 3. Case-Insensitive Matching
Handles lowercase, uppercase, and mixed-case suffixes:
- `mplus-1c-bold` → Bold
- `Font-MEDIUM` → Medium
- `Font-w6` → W6

### 4. Smart Family Name Extraction
- CamelCase to spaced names: `OpenSans` → "Open Sans"
- Preserves abbreviations: `NotoSansJP` → "Noto Sans JP"
- Multiple hyphens supported: `rounded-x-mplus-1c-light` → "rounded-x-mplus-1c"

## Resolution Chain

1. **Custom mapping** (user-provided)
2. **Static mapping** (572 built-in fonts)
3. **Suffix parsing** (NEW - this PR)
4. **None** (font not found)

## Implementation Details

### Modified Files
- `src/psd2svg/core/font_utils.py`: Core implementation (~200 lines)
  - Added suffix mapping constants (WEIGHT_SUFFIXES, COMPOUND_SUFFIXES, JAPANESE_WEIGHT_SUFFIXES)
  - Added 3 helper methods for parsing
  - Modified `lookup_static()` to use suffix parsing as fallback
- `tests/test_font_mapping.py`: Comprehensive test suite (~260 lines, 31 tests)

### Design Decisions
- **Conservative approach**: Only suffixes observed in real-world fonts
- **No breaking changes**: Return type contract preserved (`FontInfo | None`)
- **Static mapping precedence**: Existing mappings always take priority
- **Empty file field**: `file=""` indicates static/parsed (not platform-resolved)

## Examples

### PAotoGothicStdN Fonts (Medium Abbreviations)
```
PAotoGothicStdN-ExLight  → PAoto Gothic Std N | ExtraLight | CSS 200
PAotoGothicStdN-DeBold   → PAoto Gothic Std N | SemiBold   | CSS 600
PAotoGothicStdN-ExBold   → PAoto Gothic Std N | ExtraBold  | CSS 800
```

### Mplus Fonts (Lowercase Suffixes)
```
mplus-1c-bold   → mplus-1c | Bold  | CSS 700
mplus-2c-heavy  → mplus-2c | Heavy | CSS 900
```

### Rodin Fonts (Short Abbreviations)
```
RodinCattleyaPro-B   → Rodin Cattleya Pro | Bold      | CSS 700
RodinCattleyaPro-DB  → Rodin Cattleya Pro | SemiBold  | CSS 600
RodinCattleyaPro-EB  → Rodin Cattleya Pro | ExtraBold | CSS 800
```

### Japanese W-notation (Case-Insensitive)
```
HiraginoSans-w3  → Hiragino Sans | W3 | CSS 300
HiraginoSans-W6  → Hiragino Sans | W6 | CSS 600
```

## Testing

- **31 new tests** covering all suffix patterns and edge cases
- **All 62 tests pass** in `test_font_mapping.py`
- **Type checking**: mypy passes
- **Linting**: ruff passes

## Backward Compatibility

✅ Fully backward compatible:
- No changes to existing API or return types
- Static mapping behavior unchanged
- Only affects fonts previously returning `None`

## Performance

Minimal impact:
- Simple string operations (no regex)
- Dict lookups O(1)
- Only runs when static mapping lookup fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>