### PR TITLE
Fix redundant quotes in font-family attributes

### DIFF
--- a/src/psd2svg/svg_utils.py
+++ b/src/psd2svg/svg_utils.py
@@ -1352,10 +1352,10 @@ def replace_font_family(
 
     Example:
         Before: <text font-family="ArialMT">Hello</text>
-        After:  <text font-family="'Arial'">Hello</text>
+        After:  <text font-family="Arial">Hello</text>
 
-        Before: <text font-family="'ArialMT', 'Helvetica'">Hello</text>
-        After:  <text font-family="'Arial', 'Helvetica'">Hello</text>
+        Before: <text font-family="ArialMT, Helvetica">Hello</text>
+        After:  <text font-family="Arial, Helvetica">Hello</text>
 
         Before: <text style="font-family: ArialMT">Hello</text>
         After:  <text style="font-family: 'Arial'">Hello</text>
@@ -1363,7 +1363,8 @@ def replace_font_family(
     Note:
         - Replaces first occurrence of old_font_family in comma-separated list
         - If old_font_family not found, does nothing
-        - Quotes font family names in the output for CSS compliance
+        - For font-family attributes: no quotes (attribute delimiter is sufficient)
+        - For style attributes: quotes font names for CSS compliance
         - Updates font-family attribute with higher priority than style
     """
     # Check font-family attribute first (higher priority)
@@ -1376,8 +1377,8 @@ def replace_font_family(
             families = [
                 new_font_family if f == old_font_family else f for f in families
             ]
-            # Quote all families and rejoin
-            element.set("font-family", ", ".join(f"'{f}'" for f in families))
+            # No quotes for SVG attributes (attribute delimiter is sufficient)
+            element.set("font-family", ", ".join(families))
         return  # Attribute has priority, don't check style
 
     # Check style attribute for font-family
@@ -1393,7 +1394,7 @@ def replace_font_family(
                 families = [
                     new_font_family if f == old_font_family else f for f in families
                 ]
-            # Quote all families and rejoin
+            # Quote all families for CSS compliance
             return "font-family: " + ", ".join(f"'{f}'" for f in families)
 
         # Replace font-family in style attribute
@@ -1421,17 +1422,18 @@ def add_font_family(element: ET.Element, font_family: str) -> None:
 
     Example:
         Before: <text font-family="Arial">Hello</text>
-        After:  <text font-family="'Arial', 'Helvetica'">Hello</text>
+        After:  <text font-family="Arial, Helvetica">Hello</text>
 
         Before: <text style="font-family: Arial">Hello</text>
         After:  <text style="font-family: 'Arial', 'Helvetica'">Hello</text>
 
         Before: <text>Hello</text>
-        After:  <text font-family="'Helvetica'">Hello</text>
+        After:  <text font-family="Helvetica">Hello</text>
 
     Note:
         - Updates font-family attribute with higher priority than style
-        - Quotes font family names in the output for CSS compliance
+        - For font-family attributes: no quotes (attribute delimiter is sufficient)
+        - For style attributes: quotes font names for CSS compliance
         - Idempotent: does not add font if already present in the chain
         - Ignores CSS 'font' shorthand property, only handles 'font-family'
     """
@@ -1443,8 +1445,8 @@ def add_font_family(element: ET.Element, font_family: str) -> None:
         # Only add if not already present
         if font_family not in families:
             families.append(font_family)
-            # Quote all families and rejoin
-            element.set("font-family", ", ".join(f"'{f}'" for f in families))
+            # No quotes for SVG attributes (attribute delimiter is sufficient)
+            element.set("font-family", ", ".join(families))
         return  # Attribute has priority, don't check style
 
     # Check style attribute for font-family
@@ -1458,7 +1460,7 @@ def add_font_family(element: ET.Element, font_family: str) -> None:
             # Only add if not already present
             if font_family not in families:
                 families.append(font_family)
-            # Quote all families and rejoin
+            # Quote all families for CSS compliance
             return "font-family: " + ", ".join(f"'{f}'" for f in families)
 
         # Replace font-family in style attribute
@@ -1468,7 +1470,7 @@ def add_font_family(element: ET.Element, font_family: str) -> None:
         return
 
     # No font-family found, create new attribute
-    element.set("font-family", f"'{font_family}'")
+    element.set("font-family", font_family)
 
 
 def insert_or_update_style_element(svg: ET.Element, css_content: str) -> None:

--- a/tests/test_font_weight_resolution.py
+++ b/tests/test_font_weight_resolution.py
@@ -24,7 +24,7 @@ class TestFontWeightResolution:
         assert text is not None
 
         # Check that font-family was resolved and font-weight was set
-        assert text.get("font-family") == "'Arial'"
+        assert text.get("font-family") == "Arial"
         assert text.get("font-weight") == "700"  # Bold
 
     def test_italic_font_style_set_after_resolution(self) -> None:
@@ -38,7 +38,7 @@ class TestFontWeightResolution:
         ns = {"svg": "http://www.w3.org/2000/svg"}
         text = svg.find(".//svg:text", ns)
         assert text is not None
-        assert text.get("font-family") == "'Arial'"
+        assert text.get("font-family") == "Arial"
         assert text.get("font-style") == "italic"
 
     def test_bold_italic_both_set_after_resolution(self) -> None:
@@ -52,7 +52,7 @@ class TestFontWeightResolution:
         ns = {"svg": "http://www.w3.org/2000/svg"}
         text = svg.find(".//svg:text", ns)
         assert text is not None
-        assert text.get("font-family") == "'Arial'"
+        assert text.get("font-family") == "Arial"
         assert text.get("font-weight") == "700"
         assert text.get("font-style") == "italic"
 
@@ -67,7 +67,7 @@ class TestFontWeightResolution:
         ns = {"svg": "http://www.w3.org/2000/svg"}
         text = svg.find(".//svg:text", ns)
         assert text is not None
-        assert text.get("font-family") == "'Arial'"
+        assert text.get("font-family") == "Arial"
         assert text.get("font-weight") is None  # No attribute for 400 (Regular)
         assert text.get("font-style") is None
 
@@ -82,7 +82,7 @@ class TestFontWeightResolution:
         ns = {"svg": "http://www.w3.org/2000/svg"}
         text = svg.find(".//svg:text", ns)
         assert text is not None
-        assert text.get("font-family") == "'Arial'"
+        assert text.get("font-family") == "Arial"
         assert text.get("font-weight") == "bold"  # Preserved from original (faux bold)
 
     def test_preserve_existing_faux_italic(self) -> None:
@@ -96,7 +96,7 @@ class TestFontWeightResolution:
         ns = {"svg": "http://www.w3.org/2000/svg"}
         text = svg.find(".//svg:text", ns)
         assert text is not None
-        assert text.get("font-family") == "'Arial'"
+        assert text.get("font-family") == "Arial"
         assert (
             text.get("font-style") == "italic"
         )  # Preserved from original (faux italic)
@@ -105,10 +105,10 @@ class TestFontWeightResolution:
         """Test that various font weights are correctly set."""
         test_cases = [
             # (PostScript name, expected family, expected weight)
-            ("ArialMT", "'Arial'", None),  # 400 = Regular, no attribute
-            ("Arial-BoldMT", "'Arial'", "700"),  # Bold
-            ("TimesNewRomanPSMT", "'Times New Roman'", None),  # Regular
-            ("TimesNewRomanPS-BoldMT", "'Times New Roman'", "700"),  # Bold
+            ("ArialMT", "Arial", None),  # 400 = Regular, no attribute
+            ("Arial-BoldMT", "Arial", "700"),  # Bold
+            ("TimesNewRomanPSMT", "Times New Roman", None),  # Regular
+            ("TimesNewRomanPS-BoldMT", "Times New Roman", "700"),  # Bold
         ]
 
         for ps_name, expected_family, expected_weight in test_cases:
@@ -143,5 +143,5 @@ class TestFontWeightResolution:
         assert len(texts) == 3
 
         for text in texts:
-            assert text.get("font-family") == "'Arial'"
+            assert text.get("font-family") == "Arial"
             assert text.get("font-weight") == "700"

--- a/tests/test_svg_utils.py
+++ b/tests/test_svg_utils.py
@@ -1047,7 +1047,7 @@ class TestAddFontFamily:
 
         svg_utils.add_font_family(text, "Helvetica")
 
-        assert text.attrib.get("font-family") == "'Arial', 'Helvetica'"
+        assert text.attrib.get("font-family") == "Arial, Helvetica"
 
     def test_add_fallback_to_quoted_font_family(self) -> None:
         """Test adding fallback when original font-family has single quotes."""
@@ -1056,7 +1056,7 @@ class TestAddFontFamily:
 
         svg_utils.add_font_family(text, "Helvetica")
 
-        assert text.attrib.get("font-family") == "'Arial', 'Helvetica'"
+        assert text.attrib.get("font-family") == "Arial, Helvetica"
 
     def test_add_fallback_to_double_quoted_font_family(self) -> None:
         """Test adding fallback when original font-family has double quotes."""
@@ -1065,27 +1065,27 @@ class TestAddFontFamily:
 
         svg_utils.add_font_family(text, "Helvetica")
 
-        assert text.attrib.get("font-family") == "'Arial', 'Helvetica'"
+        assert text.attrib.get("font-family") == "Arial, Helvetica"
 
     def test_idempotent_does_not_add_duplicate_attribute(self) -> None:
         """Test that function is idempotent - doesn't add duplicate fallback."""
-        text = ET.Element("text", attrib={"font-family": "'Arial', 'Helvetica'"})
+        text = ET.Element("text", attrib={"font-family": "Arial, Helvetica"})
         text.text = "Hello"
 
         svg_utils.add_font_family(text, "Helvetica")
 
         # Should remain unchanged - Helvetica already present
-        assert text.attrib.get("font-family") == "'Arial', 'Helvetica'"
+        assert text.attrib.get("font-family") == "Arial, Helvetica"
 
     def test_add_second_fallback_to_chain(self) -> None:
         """Test adding a second fallback to existing fallback chain."""
-        text = ET.Element("text", attrib={"font-family": "'Arial', 'Helvetica'"})
+        text = ET.Element("text", attrib={"font-family": "Arial, Helvetica"})
         text.text = "Hello"
 
         svg_utils.add_font_family(text, "sans-serif")
 
         # Should append new fallback
-        assert text.attrib.get("font-family") == "'Arial', 'Helvetica', 'sans-serif'"
+        assert text.attrib.get("font-family") == "Arial, Helvetica, sans-serif"
 
     def test_unquoted_font_list_in_attribute(self) -> None:
         """Test handling unquoted font list in attribute."""
@@ -1099,7 +1099,7 @@ class TestAddFontFamily:
         # Should add DejaVu Sans if not present
         assert (
             text.attrib.get("font-family")
-            == "'Arial', 'Helvetica', 'sans-serif', 'DejaVu Sans'"
+            == "Arial, Helvetica, sans-serif, DejaVu Sans"
         )
 
     # Test cases for style attribute
@@ -1186,7 +1186,7 @@ class TestAddFontFamily:
         svg_utils.add_font_family(text, "Helvetica")
 
         # Attribute should be updated
-        assert text.attrib.get("font-family") == "'Arial', 'Helvetica'"
+        assert text.attrib.get("font-family") == "Arial, Helvetica"
         # Style should remain unchanged
         style = text.attrib.get("style")
         assert style is not None
@@ -1202,7 +1202,7 @@ class TestAddFontFamily:
         svg_utils.add_font_family(text, "Helvetica")
 
         # Should create new font-family attribute
-        assert text.attrib.get("font-family") == "'Helvetica'"
+        assert text.attrib.get("font-family") == "Helvetica"
         assert text.attrib.get("font-size") == "12px"
 
     def test_create_font_family_when_style_has_no_font(self) -> None:
@@ -1213,7 +1213,7 @@ class TestAddFontFamily:
         svg_utils.add_font_family(text, "Helvetica")
 
         # Should create font-family attribute (not add to style)
-        assert text.attrib.get("font-family") == "'Helvetica'"
+        assert text.attrib.get("font-family") == "Helvetica"
         # Style should remain unchanged
         style = text.attrib.get("style")
         assert style is not None
@@ -1227,7 +1227,7 @@ class TestAddFontFamily:
         svg_utils.add_font_family(text, "Helvetica")
 
         # Should create font-family attribute
-        assert text.attrib.get("font-family") == "'Helvetica'"
+        assert text.attrib.get("font-family") == "Helvetica"
 
     # Test cases with various font names
     def test_add_fallback_tspan_element(self) -> None:
@@ -1237,10 +1237,7 @@ class TestAddFontFamily:
 
         svg_utils.add_font_family(tspan, "Noto Sans CJK JP")
 
-        assert (
-            tspan.attrib.get("font-family")
-            == "'Kozuka Gothic Pr6N', 'Noto Sans CJK JP'"
-        )
+        assert tspan.attrib.get("font-family") == "Kozuka Gothic Pr6N, Noto Sans CJK JP"
 
     def test_add_fallback_with_font_name_with_spaces(self) -> None:
         """Test adding fallback for font names containing spaces."""
@@ -1249,7 +1246,7 @@ class TestAddFontFamily:
 
         svg_utils.add_font_family(text, "Liberation Serif")
 
-        assert text.attrib.get("font-family") == "'Times New Roman', 'Liberation Serif'"
+        assert text.attrib.get("font-family") == "Times New Roman, Liberation Serif"
 
     def test_mixed_quoting_styles(self) -> None:
         """Test handling of mixed quoting styles in font list."""
@@ -1263,7 +1260,7 @@ class TestAddFontFamily:
         # Should normalize quoting and add new font
         assert (
             text.attrib.get("font-family")
-            == "'Arial', 'Times New Roman', 'sans-serif', 'Helvetica'"
+            == "Arial, Times New Roman, sans-serif, Helvetica"
         )
 
     def test_whitespace_handling_in_font_names(self) -> None:
@@ -1274,7 +1271,7 @@ class TestAddFontFamily:
         svg_utils.add_font_family(text, "DejaVu Sans")
 
         # Should trim whitespace and add new font
-        assert text.attrib.get("font-family") == "'Arial', 'Helvetica', 'DejaVu Sans'"
+        assert text.attrib.get("font-family") == "Arial, Helvetica, DejaVu Sans"
 
     # Test preservation of other properties
     def test_preserve_other_style_properties(self) -> None:
@@ -1310,7 +1307,7 @@ class TestAddFontFamily:
 
         svg_utils.add_font_family(text, "Helvetica")
 
-        assert text.attrib.get("font-family") == "'Arial', 'Helvetica'"
+        assert text.attrib.get("font-family") == "Arial, Helvetica"
         assert text.attrib.get("font-size") == "12"
         assert text.attrib.get("transform") == "matrix(1,0,0,1,0,0)"
 
@@ -1332,9 +1329,7 @@ class TestAddFontFamily:
 
         svg_utils.add_font_family(text, "Noto Sans CJK JP")
 
-        assert (
-            text.attrib.get("font-family") == "'Kozuka Gothic Pr6N', 'Noto Sans CJK JP'"
-        )
+        assert text.attrib.get("font-family") == "Kozuka Gothic Pr6N, Noto Sans CJK JP"
         assert text.attrib.get("transform") == "matrix(3.36,0,-0.68,3.35,253.68,244.16)"
 
     def test_multiple_calls_build_fallback_chain(self) -> None:
@@ -1343,21 +1338,21 @@ class TestAddFontFamily:
         text.text = "Hello"
 
         svg_utils.add_font_family(text, "Helvetica")
-        assert text.attrib.get("font-family") == "'Arial', 'Helvetica'"
+        assert text.attrib.get("font-family") == "Arial, Helvetica"
 
         # Second call with same fallback - should be idempotent
         svg_utils.add_font_family(text, "Helvetica")
-        assert text.attrib.get("font-family") == "'Arial', 'Helvetica'"
+        assert text.attrib.get("font-family") == "Arial, Helvetica"
 
         # Third call with different fallback - should append
         svg_utils.add_font_family(text, "DejaVu Sans")
-        assert text.attrib.get("font-family") == "'Arial', 'Helvetica', 'DejaVu Sans'"
+        assert text.attrib.get("font-family") == "Arial, Helvetica, DejaVu Sans"
 
         # Fourth call with another fallback
         svg_utils.add_font_family(text, "sans-serif")
         assert (
             text.attrib.get("font-family")
-            == "'Arial', 'Helvetica', 'DejaVu Sans', 'sans-serif'"
+            == "Arial, Helvetica, DejaVu Sans, sans-serif"
         )
 
     def test_generic_font_family_names(self) -> None:
@@ -1367,7 +1362,7 @@ class TestAddFontFamily:
 
         svg_utils.add_font_family(text, "Helvetica")
 
-        assert text.attrib.get("font-family") == "'Arial', 'sans-serif', 'Helvetica'"
+        assert text.attrib.get("font-family") == "Arial, sans-serif, Helvetica"
 
     def test_case_sensitive_duplicate_detection(self) -> None:
         """Test that duplicate detection is case-sensitive."""
@@ -1378,7 +1373,7 @@ class TestAddFontFamily:
         svg_utils.add_font_family(text, "arial")
 
         # Should add because case doesn't match
-        assert text.attrib.get("font-family") == "'Arial', 'arial'"
+        assert text.attrib.get("font-family") == "Arial, arial"
 
     def test_only_style_updated_when_no_attribute(self) -> None:
         """Test that only style is updated when element has no font-family attribute."""


### PR DESCRIPTION
## Summary

This PR fixes a bug where `font-family` attribute values were unnecessarily wrapped in single quotes, resulting in output like `font-family="'Hira Kaku Std'"` instead of the correct `font-family="Hira Kaku Std"`.

## Problem

The `replace_font_family()` and `add_font_family()` functions in [svg_utils.py](src/psd2svg/svg_utils.py) were adding single quotes around font family names for all contexts, including SVG attributes where they are redundant.

Example of the bug:
```xml
<!-- Before (incorrect) -->
<text font-family="'Hira Kaku Std'">Text</text>

<!-- After (correct) -->
<text font-family="Hira Kaku Std">Text</text>
```

## Solution

Updated the functions to distinguish between:
- **SVG attributes**: No quotes (the attribute delimiter provides delimitation)
- **CSS in style attributes**: Quotes maintained (CSS requires them for names with spaces)

## Changes

- Fixed `replace_font_family()` to not add quotes for SVG attributes
- Fixed `add_font_family()` similarly for consistency
- Updated docstrings to clarify the different behaviors
- Updated all tests to reflect the corrected behavior

## Testing

- All existing tests pass (723 passed, 15 skipped, 15 xfailed)
- Updated test expectations to match the corrected output
- Verified with `ruff`, `mypy`, and `pytest`

## Checklist

- [x] Run tests and ensure they pass
- [x] Run linting (ruff format, ruff check)
- [x] Run type checking (mypy)
- [x] Update docstrings to reflect changes
- [x] Update test expectations

🤖 Generated with [Claude Code](https://claude.com/claude-code)