### PR TITLE
Fix redundant font-weight and font-style attributes on inherited elements

### DIFF
--- a/src/psd2svg/svg_document.py
+++ b/src/psd2svg/svg_document.py
@@ -659,8 +659,10 @@ class SVGDocument:
             # Get family name
             family_name = resolved_font.family
 
-            # Find all elements with this PostScript name
-            elements_with_font = svg_utils.find_elements_with_font_family(svg, ps_name)
+            # Find all elements with this PostScript name (direct declarations only)
+            elements_with_font = svg_utils.find_elements_with_font_family(
+                svg, ps_name, include_inherited=False
+            )
 
             if not elements_with_font:
                 # This shouldn't happen since extract_font_families() found it


### PR DESCRIPTION
## Summary

Fixes redundant `font-weight` and `font-style` attributes being added to child elements that inherit `font-family` from their parent.

## Problem

Currently, `_update_element_font_attributes()` adds font attributes to ALL elements that use a font, including child elements that only inherit the font-family from their parent. This creates redundant SVG output:

**Before:**
```xml
<text font-family="Arial" font-weight="700">
  <tspan font-weight="700">Bold</tspan>
  <tspan font-weight="700">More</tspan>
</text>
```

**After:**
```xml
<text font-family="Arial" font-weight="700">
  <tspan>Bold</tspan>
  <tspan>More</tspan>
</text>
```

## Root Cause

`find_elements_with_font_family()` walks the CSS inheritance chain to find all elements using a font. However, only elements with direct `font-family` declarations should receive `font-weight`/`font-style` attributes. Elements that inherit their font-family should inherit the weight/style as well.

## Solution

- Add `include_inherited` parameter to `find_elements_with_font_family()` (defaults to `True` for backward compatibility)
- Pass `include_inherited=False` in `_resolve_postscript_names_static()` to only update elements with direct font-family declarations
- Keep default behavior in `_extract_font_elements_and_charset()` to ensure all text characters are extracted for charset-based font matching

## Testing

- ✅ All 739 existing tests pass
- ✅ Type checking passes (mypy)
- ✅ Linting passes (ruff)
- ✅ Manual verification confirms no redundant attributes

## Changes

- `src/psd2svg/svg_utils.py`: Add `include_inherited` parameter to `find_elements_with_font_family()` and `_element_uses_font_family()`
- `src/psd2svg/svg_document.py`: Pass `include_inherited=False` in `_resolve_postscript_names_static()`

🤖 Generated with [Claude Code](https://claude.com/claude-code)