### PR TITLE
Refactor: Use fill="none" instead of fill="transparent"

### DIFF
--- a/src/psd2svg/core/color_utils.py
+++ b/src/psd2svg/core/color_utils.py
@@ -37,7 +37,7 @@ def cmyk2rgb(values: Sequence[float]) -> tuple[int, int, int]:
     )
 
 
-def descriptor2hex(desc: Descriptor, fallback: str = "transparent") -> str:
+def descriptor2hex(desc: Descriptor, fallback: str = "none") -> str:
     """Convert a color descriptor to an RGB hex string."""
 
     if desc.classID == Klass.RGBColor:

--- a/src/psd2svg/core/effects.py
+++ b/src/psd2svg/core/effects.py
@@ -259,7 +259,7 @@ class EffectConverter(ConverterProtocol):
         use = self.create_node(
             "use",
             href=svg_utils.get_uri(target),
-            fill="transparent",
+            fill="none",
             class_="stroke-effect",
         )
         # Check effect.fill_type.

--- a/src/psd2svg/core/layer.py
+++ b/src/psd2svg/core/layer.py
@@ -201,7 +201,7 @@ class LayerConverter(ConverterProtocol):
                 self.set_opacity(layer.opacity / 255.0, node)
                 node = self.apply_mask(layer, node)
 
-            # We need to set stroke for the shape here when fill is transparent.
+            # We need to set stroke for the shape here when fill is none.
             # Otherwise, effects won't use the correct alpha.
             if (
                 layer.has_stroke()
@@ -209,7 +209,7 @@ class LayerConverter(ConverterProtocol):
                 and layer.stroke.enabled
                 and not layer.stroke.fill_enabled
             ):
-                svg_utils.set_attribute(node, "fill", "transparent")
+                svg_utils.set_attribute(node, "fill", "none")
                 self.set_stroke(layer, node)
 
             self.apply_background_effects(layer, node, insert_before_target=False)

--- a/src/psd2svg/core/paint.py
+++ b/src/psd2svg/core/paint.py
@@ -66,7 +66,7 @@ class PaintConverter(ConverterProtocol):
         use = self.create_node(
             "use",
             href=svg_utils.get_uri(target),
-            fill="transparent",
+            fill="none",
             class_="stroke",
         )
         self.set_stroke(layer, use)
@@ -75,14 +75,14 @@ class PaintConverter(ConverterProtocol):
         self, layer: layers.ShapeLayer | adjustments.FillLayer, node: ET.Element
     ) -> None:
         """Set fill attribute to the given element."""
-        # Transparent fill when stroke is enabled but fill is disabled.
+        # No fill when stroke is enabled but fill is disabled.
         if (
             layer.has_stroke()
             and layer.stroke is not None
             and not layer.stroke.fill_enabled
         ):
-            logger.debug("Fill is disabled; setting fill to transparent.")
-            svg_utils.set_attribute(node, "fill", "transparent")
+            logger.debug("Fill is disabled; setting fill to none.")
+            svg_utils.set_attribute(node, "fill", "none")
             return
 
         # Shapes have the following tagged blocks for fill content.
@@ -181,7 +181,7 @@ class PaintConverter(ConverterProtocol):
             logger.warning(f"Unsupported stroke content: {stroke.content}")
 
         if not stroke.fill_enabled:
-            svg_utils.set_attribute(node, "fill", "transparent")
+            svg_utils.set_attribute(node, "fill", "none")
 
         if stroke.opacity.value < 100:
             svg_utils.set_attribute(


### PR DESCRIPTION
## Summary

Replace all instances of `fill="transparent"` with `fill="none"` for better SVG standard compliance and performance.

## Motivation

In SVG, `fill="none"` is the canonical way to indicate absence of paint, while `fill="transparent"` is technically a color value (rgba(0,0,0,0)). Using `fill="none"` is:

- More idiomatic and standards-compliant
- Slightly more performant (no color computation needed)
- Shorter in file size
- The element won't respond to pointer events on the fill area (only on strokes)

## Changes

Updated the following files:
- `src/psd2svg/core/paint.py`: Updated `apply_vector_stroke()` and `set_stroke()` methods
- `src/psd2svg/core/effects.py`: Updated `add_vector_stroke_effect()` method
- `src/psd2svg/core/layer.py`: Updated shape layer stroke handling
- `src/psd2svg/core/color_utils.py`: Changed `descriptor2hex()` fallback from "transparent" to "none"

## Testing

All pre-commit checks passed:
- ✅ Ruff formatting
- ✅ Ruff linting
- ✅ MyPy type checking
- ✅ All tests pass (740 passed, 15 skipped, 15 xfailed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)