### PR TITLE
docs: Add uv run python command to quick reference

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,6 +13,7 @@ uv run pytest                    # Run tests
 uv run mypy src/ tests/          # Type checking
 uv run ruff check src/ tests/    # Linting
 uv run ruff format src/ tests/   # Format code
+uv run python                    # Run python interpreter
 
 # Optional dependencies
 uv sync --group docs             # Documentation tools


### PR DESCRIPTION
## Summary
- Added `uv run python` command to the Essential Commands section in CLAUDE.md

## Context
This command is useful for developers who need to quickly access the Python interpreter during development and debugging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)