### PR TITLE
Fix inconsistent font-weight values (Issue #179)

### DIFF
--- a/src/psd2svg/core/text.py
+++ b/src/psd2svg/core/text.py
@@ -434,7 +434,7 @@ class TextConverter(ConverterProtocol):
         # Determine font weight - only set for faux bold (PostScript name encodes actual weight)
         font_weight: int | str | None = None
         if style.faux_bold:
-            font_weight = "bold"
+            font_weight = "700"
 
         with self.set_current(paragraph_node):
             tspan = self.create_node(
@@ -791,7 +791,7 @@ class TextConverter(ConverterProtocol):
 
         # Font weight - only set for faux bold (PostScript name encodes actual weight)
         if style.faux_bold:
-            styles["font-weight"] = "bold"
+            styles["font-weight"] = "700"
 
         # Font style - only set for faux italic (PostScript name encodes actual style)
         if style.faux_italic:

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -264,7 +264,7 @@ def test_text_style_italic() -> None:
 def test_text_style_faux_bold() -> None:
     """Test faux bold handling.
 
-    Faux bold (synthetic bold) should set font-weight="bold".
+    Faux bold (synthetic bold) should set font-weight="700".
     This ensures proper rendering even with variable fonts.
     """
     svg = convert_psd_to_svg("texts/style-faux-bold.psd")
@@ -272,10 +272,10 @@ def test_text_style_faux_bold() -> None:
     tspans = svg.findall(".//tspan[@font-weight]")
     assert len(tspans) > 0, "Should have at least one tspan with font-weight"
 
-    # Check that we have a bold tspan (font-weight="bold" for faux bold)
+    # Check that we have a bold tspan (font-weight="700" for faux bold)
     font_weights = [t.attrib.get("font-weight") for t in tspans]
-    assert "bold" in font_weights, (
-        f"Expected to find font-weight='bold' (faux bold), got: {font_weights}"
+    assert "700" in font_weights, (
+        f"Expected to find font-weight='700' (faux bold), got: {font_weights}"
     )
 
 


### PR DESCRIPTION
## Summary

Fixes inconsistent `font-weight` values in SVG output by standardizing on numeric values instead of mixing symbolic names with numeric values.

## Changes

- **src/psd2svg/core/text.py (line 437)**: Changed `font_weight = "bold"` to `font_weight = "700"`
- **src/psd2svg/core/text.py (line 794)**: Changed `styles["font-weight"] = "bold"` to `styles["font-weight"] = "700"`
- **tests/test_text.py**: Updated test to expect `"700"` instead of `"bold"`

## Benefits

- ✅ Consistent numeric values throughout SVG output
- ✅ Better precision for variable fonts
- ✅ Aligns with modern CSS practices (numeric values are preferred)
- ✅ Matches behavior of resolved font weights in `SVGDocument._update_font_attributes()`

## Testing

- All tests pass (727 passed, 29 skipped, 15 xfailed)
- Pre-commit checks pass (ruff format, ruff check, mypy)

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)