### PR TITLE
Add quotes around file path in font resolution log

### DIFF
--- a/src/psd2svg/svg_document.py
+++ b/src/psd2svg/svg_document.py
@@ -756,7 +756,7 @@ class SVGDocument:
             # Log resolution with file path
             logger.info(
                 f"Resolved font '{ps_name}' → '{family_name}' "
-                f"(file: {resolved_font.file})"
+                f"(file: '{resolved_font.file}')"
             )
 
             # Step 3: Update font-family attributes and set weight/style


### PR DESCRIPTION
## Summary

Improves readability of font resolution log messages by adding quotes around file paths.

## Changes

**Before:**
```
INFO:psd2svg.svg_document:Resolved font 'ArialMT' → 'Arial' (file: /System/Library/Fonts/Supplemental/Arial.ttf)
```

**After:**
```
INFO:psd2svg.svg_document:Resolved font 'ArialMT' → 'Arial' (file: '/System/Library/Fonts/Supplemental/Arial.ttf')
```

## Benefits

- ✅ Improved readability
- ✅ Clearer visual separation of the file path
- ✅ Better handling of paths with spaces (when they occur)
- ✅ Consistent with the quoting style used for font names in the same log message

## Testing

- All pre-commit checks pass (ruff format, ruff check, mypy)

🤖 Generated with [Claude Code](https://claude.com/claude-code)