### PR TITLE
Refactor AdjustmentConverter._create_filter to use svg_utils helpers

### DIFF
--- a/src/psd2svg/core/adjustment.py
+++ b/src/psd2svg/core/adjustment.py
@@ -734,13 +734,13 @@ class AdjustmentConverter(ConverterProtocol):
         # Backdrop use.
         self.create_node(
             "use",
-            href=f"#{wrapper.get('id')}",
+            href=svg_utils.get_uri(wrapper),
         )
         # Apply filter to the use.
         use = self.create_node(
             "use",
-            href=f"#{wrapper.get('id')}",
-            filter=f"url(#{filter.get('id')})",
+            href=svg_utils.get_uri(wrapper),
+            filter=svg_utils.get_funciri(filter),
             class_=name,
             **attrib,  # type: ignore[arg-type]  # Clipping context etc.
         )


### PR DESCRIPTION
## Summary

Refactors `AdjustmentConverter._create_filter()` method in [src/psd2svg/core/adjustment.py:728-749](src/psd2svg/core/adjustment.py#L728-L749) to use centralized `svg_utils` helper functions instead of manual string formatting.

### Changes

- Replace `f"#{wrapper.get('id')}"` with `svg_utils.get_uri(wrapper)`
- Replace `f"url(#{filter.get('id')})"` with `svg_utils.get_funciri(filter)`

### Benefits

- **Consistency**: Aligns with existing codebase patterns (same functions used elsewhere)
- **Maintainability**: Single source of truth for URI/FuncIRI formatting
- **Type safety**: Centralized error handling for missing IDs
- **Robustness**: Reduces potential for string formatting bugs

### Testing

- ✅ All pre-commit checks pass (ruff format, ruff check, mypy)
- ✅ All 35 adjustment-related tests pass
- ✅ No behavioral changes - purely refactoring

🤖 Generated with [Claude Code](https://claude.com/claude-code)