### PR TITLE
Update uv.lock to version 0.10.0

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -1325,7 +1325,7 @@ wheels = [
 
 [[package]]
 name = "psd2svg"
-version = "0.9.0"
+version = "0.10.0"
 source = { editable = "." }
 dependencies = [
     { name = "fontconfig-py", marker = "sys_platform != 'win32'" },


### PR DESCRIPTION
## Summary

Update `uv.lock` to reflect version 0.10.0. This file was not included in the v0.10.0 release commit.

## Changes

- Updates version reference in `uv.lock` from 0.9.0 to 0.10.0

## Test plan

- [x] No functional changes - only lock file update
- [x] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)