### PR TITLE
Fix font subsetting tests to use platform font resolution

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,21 +28,13 @@ def has_font(family: str) -> bool:
         True if the font is available, False otherwise.
     """
     try:
-        # Optional dependency - only available on Linux/macOS
-        import fontconfig  # noqa: PLC0415
-
-        match = fontconfig.match(
-            pattern=f":family={family}",
-            select=("family",),
-        )
-        # Fontconfig returns a fallback font if the requested one isn't found
-        # We need to check if the returned family matches what we requested
-        if not match or not match.get("family"):
+        # Try platform font resolution (works on all platforms)
+        font_info = FontInfo.resolve(family)
+        if font_info is None:
             return False
-        # Check if the returned family name matches (case-insensitive)
-        returned_family = match.get("family", "").lower()
-        requested_family = family.lower()
-        return returned_family == requested_family
+        # Check if the resolved font family matches what we requested
+        # (case-insensitive comparison to handle different naming conventions)
+        return font_info.family.lower() == family.lower()
     except Exception as e:
         logger.debug(f"Error checking font availability: {e}")
         return False
@@ -107,8 +99,8 @@ requires_noto_sans_hebrew = pytest.mark.skipif(
 )
 
 requires_arial = pytest.mark.skipif(
-    not has_postscript_font("ArialMT"),
-    reason="Arial font not installed (from MS Core Fonts)",
+    not has_font("Arial"),
+    reason="Arial font not installed",
 )
 
 

--- a/tests/test_font_subsetting.py
+++ b/tests/test_font_subsetting.py
@@ -16,7 +16,7 @@ from psd2svg.font_subsetting import (
     extract_used_unicode,
     subset_font,
 )
-from tests.conftest import get_fixture
+from tests.conftest import get_fixture, requires_arial, requires_noto_sans_jp
 
 
 class TestUnicodeExtraction:
@@ -148,14 +148,13 @@ class TestUnicodeExtraction:
 class TestFontSubsetting:
     """Tests for subset_font function."""
 
-    @pytest.mark.requires_arial
+    @requires_arial
     def test_subset_font_basic(self) -> None:
         """Test basic font subsetting with ASCII characters."""
 
         # Find Arial font
-        font_info = FontInfo.find("ArialMT")
-        if not font_info:
-            pytest.skip("Arial font not available")
+        font_info = FontInfo.resolve("Arial")
+        assert font_info is not None, "Arial font should be available"
 
         # Subset with just a few characters (as codepoints)
         codepoints = {0x41, 0x42, 0x43}  # A, B, C
@@ -170,13 +169,12 @@ class TestFontSubsetting:
         # TTF files should start with specific magic bytes
         assert font_bytes[:4] in (b"\x00\x01\x00\x00", b"OTTO", b"true")
 
-    @pytest.mark.requires_arial
+    @requires_arial
     def test_subset_font_woff2_conversion(self) -> None:
         """Test font subsetting with WOFF2 format conversion."""
 
-        font_info = FontInfo.find("ArialMT")
-        if not font_info:
-            pytest.skip("Arial font not available")
+        font_info = FontInfo.resolve("Arial")
+        assert font_info is not None, "Arial font should be available"
 
         codepoints = {0x48, 0x65, 0x6C, 0x6F, 0x57, 0x72, 0x64}  # H, e, l, o, W, r, d
         try:
@@ -189,13 +187,12 @@ class TestFontSubsetting:
         # WOFF2 files start with 'wOF2' signature
         assert font_bytes[:4] == b"wOF2"
 
-    @pytest.mark.requires_arial
+    @requires_arial
     def test_subset_font_reduces_size(self) -> None:
         """Test that subsetting significantly reduces font file size."""
 
-        font_info = FontInfo.find("ArialMT")
-        if not font_info:
-            pytest.skip("Arial font not available")
+        font_info = FontInfo.resolve("Arial")
+        assert font_info is not None, "Arial font should be available"
 
         # Small subset (3 chars)
         try:
@@ -226,15 +223,14 @@ class TestFontSubsetting:
         """Test error with unsupported font format."""
 
         with pytest.raises(ValueError, match="Unsupported font format"):
-            subset_font("/fake/path.ttf", "invalid", {0x41})  # A
+            subset_font("", "invalid", {0x41})  # A
 
-    @pytest.mark.requires_noto_sans_jp
+    @requires_noto_sans_jp
     def test_subset_font_unicode_chars(self) -> None:
         """Test subsetting with non-ASCII Unicode characters."""
 
-        font_info = FontInfo.find("NotoSansJP-Regular")
-        if not font_info:
-            pytest.skip("Noto Sans JP font not available")
+        font_info = FontInfo.resolve("Noto Sans JP")
+        assert font_info is not None, "Noto Sans JP font should be available"
 
         # Subset with Japanese characters (as codepoints)
         codepoints = {0x3053, 0x3093, 0x306B, 0x3061, 0x306F}  # こ, ん, に, ち, は


### PR DESCRIPTION
## Summary

Fixes broken font subsetting tests that were using `FontInfo.find()` (static mapping only) instead of `FontInfo.resolve()` (platform font resolution). The tests were silently failing because static mapping returns `file=''`, but font subsetting requires actual font file paths.

## Changes

### Test Fixes
- **tests/conftest.py**: Changed `requires_arial` from `has_postscript_font("ArialMT")` to `has_font("Arial")` for platform-agnostic checking
- **tests/test_font_subsetting.py**: Fixed 4 subsetting tests to use `FontInfo.resolve()` with family names:
  - `test_subset_font_basic`: `ArialMT` → `Arial`
  - `test_subset_font_woff2_conversion`: `ArialMT` → `Arial`
  - `test_subset_font_reduces_size`: `ArialMT` → `Arial`
  - `test_subset_font_unicode_chars`: `NotoSansJP-Regular` → `Noto Sans JP`

### Code Quality Improvements
- Removed 8 lines of redundant skip checks (markers handle font availability)
- Added type assertions for mypy compliance (`assert font_info is not None`)
- Replaced unsafe path `/fake/path.ttf` with empty string in invalid format test

## Impact

**Before**: 4 tests passed, 1 test skipped (Unicode test was broken)
**After**: All 5 tests now pass ✅

This also makes tests:
- More portable across platforms (works with any Arial family font, not just ArialMT PostScript name)
- Consistent with other font markers (all use `has_font()` with family names)
- Type-safe (mypy reports no issues)

## Test Results

```bash
# Font subsetting tests
$ uv run pytest tests/test_font_subsetting.py::TestFontSubsetting -v
======================== 5 passed in 0.35s =========================

# Quality tests  
$ uv run pytest tests/test_convert.py::test_text_effects_quality -v
======================== 3 passed in 0.21s =========================

# Type checking
$ uv run mypy tests/test_font_subsetting.py
Success: no issues found in 1 source file
```

## Related

This fix reveals that `has_postscript_font()` in conftest.py is now unused, and `FontInfo.find()` may be deprecated in favor of explicit `lookup_static()` / `resolve()` calls. I'll create a follow-up issue to track this cleanup.