### PR TITLE
fix: Exclude .gitignore from GitHub release assets

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,5 +38,7 @@ jobs:
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
-          files: dist/*
+          files: |
+            dist/*.whl
+            dist/*.tar.gz
           generate_release_notes: true


### PR DESCRIPTION
## Summary
- Fixed issue where `dist/.gitignore` was being uploaded to GitHub releases as `default.gitignore`
- Updated release workflow to only include `.whl` and `.tar.gz` files from the `dist/` directory

## Changes
- Modified `.github/workflows/release.yml` to use specific file patterns instead of `dist/*`

## Test plan
- Verify the workflow file syntax is correct
- When the next release is created, confirm that only wheel and tarball files are attached as assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)