### PR TITLE
Add CSS hyphens support for foreignObject mode

### DIFF
--- a/docs/configuration.rst
+++ b/docs/configuration.rst
@@ -119,6 +119,7 @@ When ``text_wrapping_mode=TextWrappingMode.FOREIGN_OBJECT``, paragraph formattin
 * **Space before** → ``margin-top``
 * **Space after** → ``margin-bottom``
 * **Hanging punctuation** → ``hanging-punctuation`` (Safari only)
+* **Auto hyphenation** → ``hyphens: auto`` + ``hyphenate-limit-chars`` (requires lang attribute)
 
 Example output:
 
@@ -127,6 +128,13 @@ Example output:
    <p style="margin: 0; padding: 0; text-indent: 26.67px; padding-left: 13.33px; margin-bottom: 20px;">
      Paragraph with first-line indent, left padding, and bottom spacing.
    </p>
+
+**Browser Support Notes:**
+
+* ``hyphens: auto`` requires the ``lang`` attribute (automatically set to ``en`` when hyphenation is enabled) and works in all modern browsers
+* ``hyphenate-limit-chars`` is supported in Firefox 43+, Safari 17+, but **not** in Chrome/Edge
+* ``hanging-punctuation`` is only supported in Safari 10+
+* PSD's ``ConsecutiveHyphens`` and ``Zone`` properties have no CSS equivalents
 
 Optimization
 ------------

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -387,9 +387,25 @@ The following paragraph formatting properties are supported in foreignObject mod
 
 The ``hanging-punctuation`` property is included in SVG output for future compatibility and Safari users, but will have no effect in other browsers.
 
+**Hyphenation Support:**
+
+Auto hyphenation (``hyphens: auto``) is supported in all modern browsers when the ``lang`` attribute is set (automatically set to ``en`` when hyphenation is enabled):
+
+* ✅ Chrome/Edge (supports ``hyphens: auto``)
+* ✅ Firefox (supports ``hyphens: auto`` and ``hyphenate-limit-chars``)
+* ✅ Safari (supports ``hyphens: auto`` and ``hyphenate-limit-chars``)
+
+However, ``hyphenate-limit-chars`` (which controls minimum word length and characters before/after hyphen) has limited support:
+
+* ❌ Chrome/Edge (not supported)
+* ✅ Firefox 43+ (supported)
+* ✅ Safari 17+ (supported)
+
+PSD's ``ConsecutiveHyphens`` and ``Zone`` properties have no CSS equivalents and are not converted.
+
 **Native SVG Limitation:**
 
-These paragraph formatting properties are only available in foreignObject mode. Native SVG ``<text>`` elements do not support paragraph indentation, spacing, or hanging punctuation.
+These paragraph formatting properties are only available in foreignObject mode. Native SVG ``<text>`` elements do not support paragraph indentation, spacing, hanging punctuation, or hyphenation.
 
 **Font Requirements:**
 


### PR DESCRIPTION
## Summary

Implements CSS `hyphens: auto` and `hyphenate-limit-chars` properties for foreignObject text rendering based on PSD's AutoHyphenate property.

## Changes

### Core Implementation
- **[src/psd2svg/core/text.py](src/psd2svg/core/text.py)**
  - Added hyphenation CSS properties to `_get_foreign_object_paragraph_styles()` method
  - Maps PSD's `AutoHyphenate` to CSS `hyphens: auto`
  - Maps `HyphenatedWordSize`, `PreHyphen`, `PostHyphen` to CSS `hyphenate-limit-chars`
  - Conditionally adds `lang="en"` attribute to foreignObject container only when hyphenation is enabled

### Testing
- **[tests/test_text.py](tests/test_text.py)**
  - Added `test_foreignobject_paragraph_hyphenation()` test case
  - Tests hyphenation CSS property generation
  - Verifies `lang="en"` attribute is set when hyphenation is enabled
  - Validates `hyphenate-limit-chars` format and values
  - Uses existing `paragraph-auto-hyphenate.psd` fixture

### Documentation
- **[docs/configuration.rst](docs/configuration.rst)**
  - Added hyphenation to supported paragraph formatting properties
  - Documented browser support notes for `hyphens: auto` and `hyphenate-limit-chars`
  
- **[docs/limitations.rst](docs/limitations.rst)**
  - Detailed browser compatibility for hyphenation features
  - Documented PSD properties without CSS equivalents (ConsecutiveHyphens, Zone)

## Browser Support

| CSS Property | Chrome/Edge | Firefox | Safari |
|-------------|------------|---------|--------|
| `hyphens: auto` | ✅ | ✅ | ✅ |
| `hyphenate-limit-chars` | ❌ | ✅ 43+ | ✅ 17+ |

**Notes:**
- `hyphens: auto` works in all modern browsers when `lang` attribute is set
- `hyphenate-limit-chars` is **not supported** in Chrome/Edge
- PSD's `ConsecutiveHyphens` and `Zone` properties have no CSS equivalents

## Implementation Details

The implementation follows the same pattern as the existing hanging punctuation feature (#252):

1. **Conditional lang attribute**: Only adds `lang="en"` when at least one paragraph has `AutoHyphenate=True`, avoiding unnecessary attributes
2. **CSS property mapping**: Converts PSD hyphenation parameters to CSS format
3. **Browser compatibility**: Documented limitations for `hyphenate-limit-chars`

## Testing

All tests pass:
```bash
uv run pytest tests/test_text.py::test_foreignobject_paragraph_hyphenation -v  # New test
uv run pytest tests/test_text.py -k foreignobject -v  # All foreignObject tests (10 passed)
uv run pytest tests/test_text.py  # All text tests (102 passed)
uv run mypy src/psd2svg/core/text.py tests/test_text.py  # Type checking
uv run ruff check src/psd2svg/core/text.py tests/test_text.py  # Linting
```

## Related Issues

Related to #252 (paragraph formatting for foreignObject mode)

🤖 Generated with [Claude Code](https://claude.com/claude-code)