### PR TITLE
Remove unnecessary font-family from foreignObject container

### DIFF
--- a/src/psd2svg/core/text.py
+++ b/src/psd2svg/core/text.py
@@ -676,7 +676,6 @@ class TextConverter(ConverterProtocol):
             "padding": "0",
             "overflow": "hidden",  # Match Photoshop clipping behavior
             "box-sizing": "border-box",
-            "font-family": "sans-serif",  # Default fallback
         }
 
         if text_setting.writing_direction == WritingDirection.VERTICAL_RL:


### PR DESCRIPTION
## Summary

Removes the unnecessary `font-family: sans-serif` default from the foreignObject container styles in `_get_foreign_object_container_styles()`.

## Analysis

The container's `font-family` property is redundant because:

1. **Individual spans set their own font-family**: Each `<span>` element gets its own `font-family` property set to the PostScript font name at lines 868-869 when a valid PostScript name is available
2. **CSS inheritance is properly handled**: The container's font-family only applies to text without its own font-family specified, but every span with a valid PostScript name already has one
3. **Edge case is rare**: This only matters if `postscript_name` is `None` or empty, which represents malformed/invalid data - not a normal use case
4. **Browser defaults exist**: If the container doesn't specify font-family, browsers use their default font anyway

## Changes

- **File**: `src/psd2svg/core/text.py:679`
- **Change**: Removed `"font-family": "sans-serif"` line from container styles

## Testing

- ✅ All 102 text tests pass
- ✅ Full test suite passes (930 passed)
- ✅ Code quality checks pass (ruff format, ruff check, mypy)

## Impact

- **No functional change**: Since individual spans already set font-family explicitly, removing the container default doesn't affect normal rendering
- **Cleaner code**: Removes defensive code that provides no clear benefit

Fixes #260

🤖 Generated with [Claude Code](https://claude.com/claude-code)