### PR TITLE
Add text configuration attributes to ConverterProtocol

### DIFF
--- a/src/psd2svg/core/base.py
+++ b/src/psd2svg/core/base.py
@@ -27,6 +27,10 @@ class ConverterProtocol(Protocol):
     enable_title: bool
     enable_class: bool
 
+    # Text conversion configuration
+    text_letter_spacing_offset: float
+    text_wrapping_mode: int
+
     def add_layer(
         self, layer: layers.Layer, depth: int = 0, **attrib: str
     ) -> ET.Element | None: ...

--- a/src/psd2svg/core/text.py
+++ b/src/psd2svg/core/text.py
@@ -103,8 +103,7 @@ class TextConverter(ConverterProtocol):
         # Determine if we should use foreignObject
         # Only use for bounding box text when explicitly enabled
         use_foreign_object = (
-            hasattr(self, "text_wrapping_mode")
-            and self.text_wrapping_mode == TextWrappingMode.FOREIGN_OBJECT
+            self.text_wrapping_mode == TextWrappingMode.FOREIGN_OBJECT
             and text_setting.shape_type == ShapeType.BOUNDING_BOX
         )
 
@@ -532,8 +531,7 @@ class TextConverter(ConverterProtocol):
         # letter-spacing applies after the character.
         letter_spacing = style.tracking / 1000 * scaled_font_size
         letter_spacing -= style.tsume / 10 * scaled_font_size  # Tsume tightens spacing
-        if hasattr(self, "text_letter_spacing_offset"):
-            letter_spacing += self.text_letter_spacing_offset
+        letter_spacing += self.text_letter_spacing_offset
 
         # Only set letter-spacing if non-zero (or if offset makes it non-zero)
         if letter_spacing != 0:
@@ -902,8 +900,7 @@ class TextConverter(ConverterProtocol):
 
         # Letter spacing
         letter_spacing = style.tracking / 1000 * style.font_size
-        if hasattr(self, "text_letter_spacing_offset"):
-            letter_spacing += self.text_letter_spacing_offset
+        letter_spacing += self.text_letter_spacing_offset
         if letter_spacing != 0:
             styles["letter-spacing"] = svg_utils.num2str_with_unit(letter_spacing)
 


### PR DESCRIPTION
## Summary

This PR adds `text_letter_spacing_offset` and `text_wrapping_mode` to the `ConverterProtocol`, making these attributes explicit requirements of the converter interface and eliminating the need for defensive `hasattr()` checks.

## Problem

Previously, these attributes were only defined in the `Converter` class implementation, requiring defensive `hasattr()` checks in the `TextConverter` mixin:

```python
# Before: Required defensive check
if hasattr(self, "text_wrapping_mode"):
    ...
```

## Solution

Add both attributes to the `ConverterProtocol` to make them part of the interface contract:

```python
class ConverterProtocol(Protocol):
    # ... existing attributes ...
    
    # Text conversion configuration
    text_letter_spacing_offset: float
    text_wrapping_mode: int
```

## Changes

### Files Modified

1. **src/psd2svg/core/base.py**
   - Added `text_letter_spacing_offset: float` to protocol
   - Added `text_wrapping_mode: int` to protocol

2. **src/psd2svg/core/text.py**
   - Removed defensive `hasattr()` check in `create_text_node()` (line 106)
   - Removed defensive `hasattr()` check in `_create_native_svg_text()` (line 535)
   - Removed defensive `hasattr()` check in `_create_foreign_object_text()` (line 905)

## Benefits

- ✅ **Better type safety**: Protocol explicitly declares required attributes
- ✅ **Cleaner code**: Eliminates 3 defensive `hasattr()` checks
- ✅ **Consistency**: Follows the pattern of existing flags (`enable_live_shapes`, etc.)
- ✅ **Documentation**: Protocol serves as clear interface documentation

## Testing

- ✅ All 102 text tests pass
- ✅ Full test suite: 936 passed, 13 skipped, 15 xfailed, 2 xpassed
- ✅ Type checking passes: `mypy` validates 60 source files
- ✅ Linting passes: `ruff check` with no issues

## Risk Assessment

**Risk Level: Low**

- The `Converter` class already initializes both attributes
- Tests already exercise these code paths extensively
- No changes to public API or behavior
- Only removes defensive checks that were always passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)