### PR TITLE
docs: clean up CLAUDE.md and update repository URLs

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -14,11 +14,11 @@ body:
       label: Pre-submission Checklist
       description: Please verify the following before submitting
       options:
-        - label: I have searched the [existing issues](https://github.com/kyamagu/psd2svg/issues) and this bug has not been reported
+        - label: I have searched the [existing issues](https://github.com/CyberAgent/psd2svg/issues) and this bug has not been reported
           required: true
         - label: I have reviewed the [Known Limitations](https://psd2svg.readthedocs.io/en/latest/limitations.html) and this is not a known limitation
           required: true
-        - label: This is not a security vulnerability (those should be reported via [SECURITY.md](https://github.com/kyamagu/psd2svg/blob/main/SECURITY.md))
+        - label: This is not a security vulnerability (those should be reported via [SECURITY.md](https://github.com/CyberAgent/psd2svg/blob/main/SECURITY.md))
           required: true
 
   - type: textarea

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -4,7 +4,7 @@ contact_links:
     url: https://psd2svg.readthedocs.io/
     about: Read the full documentation for usage guides and API reference
   - name: Security Vulnerability
-    url: https://github.com/kyamagu/psd2svg/security/advisories/new
+    url: https://github.com/CyberAgent/psd2svg/security/advisories/new
     about: Report security vulnerabilities privately (do not open a public issue)
   - name: Known Limitations
     url: https://psd2svg.readthedocs.io/en/latest/limitations.html

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -14,7 +14,7 @@ body:
       label: Pre-submission Checklist
       description: Please verify the following before submitting
       options:
-        - label: I have searched the [existing issues](https://github.com/kyamagu/psd2svg/issues) and this feature has not been requested
+        - label: I have searched the [existing issues](https://github.com/CyberAgent/psd2svg/issues) and this feature has not been requested
           required: true
         - label: I have reviewed the [documentation](https://psd2svg.readthedocs.io/) and this feature doesn't already exist
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -23,7 +23,7 @@ Closes #
 
 <!-- Verify all items before submitting. All checks must pass for merge. -->
 
-- [ ] I have read the [CONTRIBUTING.md](https://github.com/kyamagu/psd2svg/blob/main/CONTRIBUTING.md) guidelines
+- [ ] I have read the [CONTRIBUTING.md](https://github.com/CyberAgent/psd2svg/blob/main/CONTRIBUTING.md) guidelines
 - [ ] My code follows the project's code quality standards
 - [ ] I have run `uv run ruff format src/ tests/` to format the code
 - [ ] I have run `uv run ruff check src/ tests/` and fixed all linting issues

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -293,11 +293,11 @@ See [limitations.rst](https://psd2svg.readthedocs.io/en/latest/limitations.html)
 
 Previous releases - see git history for details.
 
-[0.11.0]: https://github.com/kyamagu/psd2svg/compare/v0.10.1...v0.11.0
-[0.10.1]: https://github.com/kyamagu/psd2svg/compare/v0.10.0...v0.10.1
-[0.10.0]: https://github.com/kyamagu/psd2svg/compare/v0.9.0...v0.10.0
-[0.9.0]: https://github.com/kyamagu/psd2svg/compare/v0.8.0...v0.9.0
-[0.8.0]: https://github.com/kyamagu/psd2svg/compare/v0.7.1...v0.8.0
-[0.7.1]: https://github.com/kyamagu/psd2svg/compare/v0.7.0...v0.7.1
-[0.7.0]: https://github.com/kyamagu/psd2svg/compare/v0.6.0...v0.7.0
-[0.6.0]: https://github.com/kyamagu/psd2svg/releases/tag/v0.6.0
+[0.11.0]: https://github.com/CyberAgent/psd2svg/compare/v0.10.1...v0.11.0
+[0.10.1]: https://github.com/CyberAgent/psd2svg/compare/v0.10.0...v0.10.1
+[0.10.0]: https://github.com/CyberAgent/psd2svg/compare/v0.9.0...v0.10.0
+[0.9.0]: https://github.com/CyberAgent/psd2svg/compare/v0.8.0...v0.9.0
+[0.8.0]: https://github.com/CyberAgent/psd2svg/compare/v0.7.1...v0.8.0
+[0.7.1]: https://github.com/CyberAgent/psd2svg/compare/v0.7.0...v0.7.1
+[0.7.0]: https://github.com/CyberAgent/psd2svg/compare/v0.6.0...v0.7.0
+[0.6.0]: https://github.com/CyberAgent/psd2svg/releases/tag/v0.6.0

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,5 @@
 # CLAUDE.md
 
-This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
-
 ## Quick Reference
 
 ### Essential Commands
@@ -77,25 +75,9 @@ src/psd2svg/
 │   └── morisawa_fonts.json    # Morisawa font mappings (~4,042 fonts)
 └── tools/                     # CLI tools
     └── generate_font_mapping.py  # Generate custom font mappings
-
-tests/                         # Test suite
-docs/                          # Sphinx documentation
 ```
 
 For detailed architecture documentation, see [docs/development.rst](docs/development.rst).
-
-## Important Considerations
-
-For detailed information about SVG features, text layer conversion, font embedding, and advanced configuration options, see:
-
-- **Configuration**: [docs/configuration.rst](docs/configuration.rst)
-- **Limitations**: [docs/limitations.rst](docs/limitations.rst)
-- **Font embedding**: [docs/fonts.rst](docs/fonts.rst)
-- **Rasterization**: [docs/rasterizers.rst](docs/rasterizers.rst)
-
-## Testing
-
-For test setup, font requirements, and pytest markers, see [docs/development.rst](docs/development.rst).
 
 ## CI/CD
 
@@ -145,26 +127,11 @@ gh pr create --title "My Change" --body "Description"
 ### When Making Changes
 
 1. **Create a git branch** - Always work on a feature branch, never directly on main
-2. **Read files before modifying** - Understand existing patterns
-3. **Avoid over-engineering** - Keep changes focused and minimal
-4. **Security** - Watch for command injection, XSS, SQL injection
-5. **Avoid backwards-compatibility hacks** - Delete unused code completely
-6. **No time estimates** - Provide concrete steps, not timelines
-
-### File Operations
-
-Prefer specialized tools over bash:
-
-- **Read** for reading files (not `cat`/`head`/`tail`)
-- **Edit** for editing (not `sed`/`awk`)
-- **Write** for creating files (not `echo >` or `cat <<EOF`)
-- **Glob** for finding files (not `find`)
-- **Grep** for searching content (not `grep`/`rg`)
+2. **Avoid backwards-compatibility hacks** - Delete unused code completely
 
 ### Documentation Structure
 
 - **README.md** - Quick start guide, basic usage
-- **CLAUDE.md** (this file) - Development guidance for Claude Code
 - **docs/** - Full Sphinx documentation (comprehensive details)
 
 For detailed feature documentation, configuration options, and usage examples, refer to the [full documentation](https://psd2svg.readthedocs.io/).

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -36,7 +36,7 @@ This Code of Conduct applies within all community spaces, and also applies when 
 
 ## Enforcement
 
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by opening a [GitHub Security Advisory](https://github.com/kyamagu/psd2svg/security/advisories/new) or by contacting the project maintainer through GitHub. All complaints will be reviewed and investigated promptly and fairly.
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported to the community leaders responsible for enforcement by opening a [GitHub Security Advisory](https://github.com/CyberAgent/psd2svg/security/advisories/new) or by contacting the project maintainer through GitHub. All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the reporter of any incident.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE_OF_CONDU
 
 ### Reporting Bugs
 
-Before creating a bug report, check the [existing issues](https://github.com/kyamagu/psd2svg/issues) and review the [Known Limitations](https://psd2svg.readthedocs.io/en/latest/limitations.html).
+Before creating a bug report, check the [existing issues](https://github.com/CyberAgent/psd2svg/issues) and review the [Known Limitations](https://psd2svg.readthedocs.io/en/latest/limitations.html).
 
 Use the [Bug Report template](.github/ISSUE_TEMPLATE/bug_report.yml) which will guide you through providing:
 
@@ -40,7 +40,7 @@ Quick setup:
 
 ```bash
 # Clone and install dependencies
-git clone https://github.com/kyamagu/psd2svg.git
+git clone https://github.com/CyberAgent/psd2svg.git
 cd psd2svg
 uv sync
 
@@ -116,7 +116,7 @@ For detailed standards, architecture information, and development practices, see
 ## Getting Help
 
 - **Documentation**: [psd2svg.readthedocs.io](https://psd2svg.readthedocs.io/)
-- **Issues**: [GitHub Issues](https://github.com/kyamagu/psd2svg/issues)
+- **Issues**: [GitHub Issues](https://github.com/CyberAgent/psd2svg/issues)
 - **Questions**: Open an issue with the "question" label
 
 ## License

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,7 +21,7 @@ Please **do not** create a public GitHub issue for security vulnerabilities. Pub
 
 ### 2. Report Privately
 
-Report security vulnerabilities by opening a [GitHub Security Advisory](https://github.com/kyamagu/psd2svg/security/advisories/new).
+Report security vulnerabilities by opening a [GitHub Security Advisory](https://github.com/CyberAgent/psd2svg/security/advisories/new).
 
 Alternatively, you can email the maintainer directly. Check the repository for contact information.
 
@@ -69,7 +69,7 @@ This project uses automated security scanning:
 - **Safety**: Dependency security checker
 - **Trivy**: Comprehensive security scanner
 
-Security scan results are available in the [Security tab](https://github.com/kyamagu/psd2svg/security).
+Security scan results are available in the [Security tab](https://github.com/CyberAgent/psd2svg/security).
 
 ## Acknowledgments
 
@@ -77,4 +77,4 @@ We appreciate security researchers who responsibly disclose vulnerabilities. Con
 
 ## Questions?
 
-If you have questions about this security policy, please open an issue in the [Issues tab](https://github.com/kyamagu/psd2svg/issues) with the "question" label.
+If you have questions about this security policy, please open an issue in the [Issues tab](https://github.com/CyberAgent/psd2svg/issues) with the "question" label.

--- a/docs/development.rst
+++ b/docs/development.rst
@@ -18,7 +18,7 @@ Clone the Repository
 
 .. code-block:: bash
 
-   git clone https://github.com/kyamagu/psd2svg.git
+   git clone https://github.com/CyberAgent/psd2svg.git
    cd psd2svg
 
 Install Dependencies
@@ -498,6 +498,6 @@ Manual publishing is not necessary as the release workflow handles this automati
 Getting Help
 ------------
 
-* **Issues**: Report bugs and ask questions on `GitHub Issues <https://github.com/kyamagu/psd2svg/issues>`_
+* **Issues**: Report bugs and ask questions on `GitHub Issues <https://github.com/CyberAgent/psd2svg/issues>`_
 * **Documentation**: Refer to `psd2svg.readthedocs.io <https://psd2svg.readthedocs.io/>`_
-* **Security**: Report vulnerabilities privately following `SECURITY.md <https://github.com/kyamagu/psd2svg/blob/main/SECURITY.md>`_
+* **Security**: Report vulnerabilities privately following `SECURITY.md <https://github.com/CyberAgent/psd2svg/blob/main/SECURITY.md>`_

--- a/docs/limitations.rst
+++ b/docs/limitations.rst
@@ -701,7 +701,7 @@ If you encounter issues not listed here:
 
 1. Check if it's a known limitation
 2. Test with simplified PSD files
-3. Report issues at: https://github.com/kyamagu/psd2svg/issues
+3. Report issues at: https://github.com/CyberAgent/psd2svg/issues
 
 Include:
 

--- a/docs/security.rst
+++ b/docs/security.rst
@@ -478,8 +478,8 @@ Security Updates
 
 Security features and fixes are documented in the changelog. Subscribe to:
 
-- **GitHub Security Advisories**: https://github.com/kyamagu/psd2svg/security/advisories
-- **Release Notes**: https://github.com/kyamagu/psd2svg/releases
+- **GitHub Security Advisories**: https://github.com/CyberAgent/psd2svg/security/advisories
+- **Release Notes**: https://github.com/CyberAgent/psd2svg/releases
 - **Dependabot Alerts**: Enable for your repository
 
 Reporting Security Issues
@@ -490,6 +490,6 @@ See ``SECURITY.md`` in the repository root for instructions on reporting securit
 Additional Resources
 ====================
 
-- `SECURITY.md <https://github.com/kyamagu/psd2svg/blob/main/SECURITY.md>`_ - Security policy
+- `SECURITY.md <https://github.com/CyberAgent/psd2svg/blob/main/SECURITY.md>`_ - Security policy
 - `OWASP Secure Coding Practices <https://owasp.org/www-project-secure-coding-practices-quick-reference-guide/>`_
 - `CWE Top 25 <https://cwe.mitre.org/top25/archive/2023/2023_top25_list.html>`_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,8 +55,8 @@ docs = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/kyamagu/psd2svg"
-Repository = "https://github.com/kyamagu/psd2svg"
+Homepage = "https://github.com/CyberAgent/psd2svg"
+Repository = "https://github.com/CyberAgent/psd2svg"
 
 [project.scripts]
 psd2svg = "psd2svg.__main__:main"


### PR DESCRIPTION
## Summary

- Remove redundant content from `CLAUDE.md`: generic Claude Code guidance already enforced by the system prompt (File Operations tool list, "read before modifying", "avoid over-engineering"), self-referential text, and doc links duplicated in the Important Links section
- Update all `github.com/kyamagu/psd2svg` URLs to `github.com/CyberAgent/psd2svg` across 12 files (docs, templates, `pyproject.toml`)

## Test plan

- [ ] Verify links in updated files resolve correctly under the CyberAgent org
- [ ] Confirm no `kyamagu/psd2svg` references remain (`grep -r kyamagu .`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)