### PR TITLE
Merge tspans differing only in dx/dy into coordinate lists

### DIFF
--- a/src/psd2svg/core/text.py
+++ b/src/psd2svg/core/text.py
@@ -210,6 +210,7 @@ class TextConverter(ConverterProtocol):
                     excludes={"x", "y", "dx", "dy", "transform"},
                 )
                 svg_utils.merge_consecutive_siblings(child)
+                svg_utils.merge_offset_siblings(child)
                 svg_utils.merge_singleton_children(child)
                 svg_utils.merge_attribute_less_children(child)
         else:
@@ -218,6 +219,7 @@ class TextConverter(ConverterProtocol):
                 excludes={"x", "y", "dx", "dy", "transform"},
             )
             svg_utils.merge_consecutive_siblings(text_node)
+            svg_utils.merge_offset_siblings(text_node)
             svg_utils.merge_singleton_children(text_node)
             svg_utils.merge_attribute_less_children(text_node)
         return text_node

--- a/src/psd2svg/svg_utils.py
+++ b/src/psd2svg/svg_utils.py
@@ -855,6 +855,208 @@ def merge_consecutive_siblings(element: ET.Element) -> None:
             i += 1
 
 
+# Attributes that can be expressed as per-character coordinate lists on an SVG
+# element. Every other attribute is treated as "style" and must match exactly
+# for two elements to be merged by merge_offset_siblings.
+_POSITIONAL_ATTRS = ("x", "y", "dx", "dy")
+
+
+def _non_positional_attrib(element: ET.Element) -> dict[str, str]:
+    """Return an element's attributes excluding positional coordinate ones."""
+    return {
+        key: value
+        for key, value in element.attrib.items()
+        if key not in _POSITIONAL_ATTRS
+    }
+
+
+def _has_combining_marks(text: str) -> bool:
+    """Return True if text contains Unicode combining marks (Mn/Mc/Me).
+
+    Combining marks make Python's ``len(text)`` diverge from the number of
+    addressable characters an SVG renderer counts, which would misalign the
+    per-character coordinate lists built by merge_offset_siblings. Groups that
+    contain them are therefore left unmerged.
+    """
+    return any(unicodedata.category(char) in ("Mn", "Mc", "Me") for char in text)
+
+
+def _serialize_relative_offsets(values: list[str | None]) -> str | None:
+    """Serialize a relative (dx/dy) coordinate list.
+
+    Unset entries default to 0 and trailing zeros are trimmed, since a relative
+    offset defaults to 0 for characters past the end of the list.
+
+    Returns:
+        The space-separated list, or None if every entry is zero/unset.
+    """
+    last_nonzero = -1
+    for index, value in enumerate(values):
+        if value is not None and float(value) != 0.0:
+            last_nonzero = index
+    if last_nonzero < 0:
+        return None
+    return " ".join(values[index] or "0" for index in range(last_nonzero + 1))
+
+
+def _serialize_absolute_offsets(
+    values: list[str | None],
+) -> tuple[bool, str | None]:
+    """Serialize an absolute (x/y) coordinate list.
+
+    Unlike relative offsets, an absolute coordinate list has no way to express
+    an "unset" character in the middle of the list (there is no natural-advance
+    sentinel). A group that would require such a gap cannot be merged.
+
+    Returns:
+        A ``(ok, value)`` tuple. ``ok`` is False when an internal gap would be
+        required. ``value`` is None when no entry is set.
+    """
+    last_set = -1
+    for index, value in enumerate(values):
+        if value is not None:
+            last_set = index
+    if last_set < 0:
+        return True, None
+    prefix = values[: last_set + 1]
+    if any(value is None for value in prefix):
+        return False, None
+    return True, " ".join(value for value in prefix if value is not None)
+
+
+def _merge_offset_group(parent: ET.Element, group: list[ET.Element]) -> bool:
+    """Merge a run of leaf siblings into the first element with position lists.
+
+    Args:
+        parent: The parent element that owns the group.
+        group: Consecutive leaf siblings sharing identical non-positional
+            attributes.
+
+    Returns:
+        True if the group was merged (positional attributes rewritten as lists
+        and the remaining members removed). False if the group cannot be safely
+        merged, in which case the tree is left unchanged.
+    """
+    texts = [element.text or "" for element in group]
+
+    # Combining marks make len(text) diverge from the addressable-character
+    # count, which would misalign the coordinate lists.
+    if any(_has_combining_marks(text) for text in texts):
+        return False
+
+    # Build per-character value lists (None marks an unset position).
+    per_char: dict[str, list[str | None]] = {attr: [] for attr in _POSITIONAL_ATTRS}
+    for element, text in zip(group, texts):
+        char_count = len(text)
+        for attr in _POSITIONAL_ATTRS:
+            value = element.attrib.get(attr)
+            if char_count == 0:
+                # An empty span hosts no character, so a coordinate on it is
+                # ambiguous and the group cannot be merged safely.
+                if value is not None:
+                    return False
+                continue
+            per_char[attr].append(value)
+            per_char[attr].extend([None] * (char_count - 1))
+
+    serialized: dict[str, str | None] = {}
+    for attr in ("dx", "dy"):
+        serialized[attr] = _serialize_relative_offsets(per_char[attr])
+    for attr in ("x", "y"):
+        ok, value = _serialize_absolute_offsets(per_char[attr])
+        if not ok:
+            return False
+        serialized[attr] = value
+
+    merged = group[0]
+    merged.text = "".join(texts) or None
+    for attr in _POSITIONAL_ATTRS:
+        value = serialized[attr]
+        if value is None:
+            merged.attrib.pop(attr, None)
+        else:
+            merged.attrib[attr] = value
+    # Only the last member may carry a tail (see merge_offset_siblings), so
+    # preserving it keeps any following content in place.
+    merged.tail = group[-1].tail
+    for element in group[1:]:
+        parent.remove(element)
+    return True
+
+
+def merge_offset_siblings(element: ET.Element) -> None:
+    """Recursively merge consecutive siblings that differ only in position.
+
+    Photoshop kerning is emitted as a ``dx`` value on individual per-character
+    <tspan> elements, so merge_consecutive_siblings (which only merges elements
+    with identical attributes) leaves them unmerged. This function consolidates
+    such runs into a single element carrying per-character coordinate lists,
+    turning e.g.
+
+        <tspan>a</tspan><tspan dx="0.1">b</tspan><tspan>c</tspan>
+
+    into
+
+        <tspan dx="0 0.1">abc</tspan>
+
+    The ``x``/``y``/``dx``/``dy`` attributes become space-separated lists whose
+    n-th value applies to the n-th character of the merged text.
+
+    Args:
+        element: The XML element to process recursively.
+
+    Note:
+        - Only leaf elements (no child elements) are merged.
+        - Non-positional attributes must be identical across the whole group.
+        - ``dx``/``dy`` are relative (default 0), so gaps are filled with 0 and
+          trailing zeros are trimmed.
+        - ``x``/``y`` are absolute; a group that would need an internal unset
+          gap is left unmerged.
+    """
+    # First, recursively process all children
+    for child in list(element):
+        merge_offset_siblings(child)
+
+    children = list(element)
+    if len(children) < 2:
+        return
+
+    i = 0
+    while i < len(children):
+        current = children[i]
+
+        # Skip elements with children (don't merge complex structures)
+        if len(current) > 0:
+            i += 1
+            continue
+
+        current_style = _non_positional_attrib(current)
+
+        # Collect a run of mergeable leaf siblings with matching style.
+        group = [current]
+        j = i + 1
+        while j < len(children):
+            next_elem = children[j]
+            if len(next_elem) > 0:
+                break
+            if next_elem.tag != current.tag:
+                break
+            if _non_positional_attrib(next_elem) != current_style:
+                break
+            # A non-empty tail carries content that merging would drop, so stop
+            # the run before crossing it.
+            if group[-1].tail:
+                break
+            group.append(next_elem)
+            j += 1
+
+        if len(group) >= 2 and _merge_offset_group(element, group):
+            # The merged element remains at index i; refresh and re-scan.
+            children = list(element)
+        else:
+            i += 1
+
+
 def merge_singleton_children(element: ET.Element) -> None:
     """Recursively merge singleton child nodes into their parent nodes.
 

--- a/tests/test_svg_utils.py
+++ b/tests/test_svg_utils.py
@@ -777,6 +777,165 @@ class TestMergeConsecutiveSiblings:
         assert text[0].text == "Only child"
 
 
+class TestMergeOffsetSiblings:
+    """Tests for merge_offset_siblings utility function."""
+
+    def test_merge_dx_into_list(self) -> None:
+        """Consecutive tspans differing only in dx merge into a dx list."""
+        text = ET.fromstring(
+            '<text><tspan>a</tspan><tspan dx="0.1">b</tspan><tspan>c</tspan></text>'
+        )
+
+        svg_utils.merge_offset_siblings(text)
+
+        assert len(text) == 1
+        assert text[0].text == "abc"
+        # Trailing zero for 'c' is trimmed (dx defaults to 0 past the list end).
+        assert text[0].attrib["dx"] == "0 0.1"
+
+    def test_merge_dy_into_list(self) -> None:
+        """dy offsets are merged the same way as dx."""
+        text = ET.fromstring(
+            '<text><tspan>a</tspan><tspan dy="2">b</tspan>'
+            '<tspan dy="3">c</tspan></text>'
+        )
+
+        svg_utils.merge_offset_siblings(text)
+
+        assert len(text) == 1
+        assert text[0].text == "abc"
+        assert text[0].attrib["dy"] == "0 2 3"
+
+    def test_multi_character_spans(self) -> None:
+        """A dx applies only to the first char of a multi-character span."""
+        text = ET.fromstring('<text><tspan>ab</tspan><tspan dx="-1">cd</tspan></text>')
+
+        svg_utils.merge_offset_siblings(text)
+
+        assert len(text) == 1
+        assert text[0].text == "abcd"
+        # Chars: a=0, b=0, c=-1, d=0(trimmed) -> "0 0 -1".
+        assert text[0].attrib["dx"] == "0 0 -1"
+
+    def test_first_span_keeps_absolute_position(self) -> None:
+        """x/y on the first char and dx on the rest merge together."""
+        text = ET.fromstring(
+            '<text><tspan x="10" y="20">L</tspan>'
+            '<tspan dx="-0.8">o</tspan><tspan dx="-3.2">r</tspan></text>'
+        )
+
+        svg_utils.merge_offset_siblings(text)
+
+        assert len(text) == 1
+        merged = text[0]
+        assert merged.text == "Lor"
+        assert merged.attrib["x"] == "10"
+        assert merged.attrib["y"] == "20"
+        assert merged.attrib["dx"] == "0 -0.8 -3.2"
+
+    def test_no_merge_on_absolute_gap(self) -> None:
+        """An internal unset x cannot be expressed as a list, so no merge."""
+        text = ET.fromstring(
+            '<text><tspan x="10">ab</tspan><tspan x="50">c</tspan></text>'
+        )
+
+        svg_utils.merge_offset_siblings(text)
+
+        # 'b' would need an unset (natural-advance) x between the two set
+        # values, which an SVG coordinate list cannot express.
+        assert len(text) == 2
+
+    def test_no_merge_different_style(self) -> None:
+        """Spans differing in a non-positional attribute are not merged."""
+        text = ET.fromstring(
+            '<text><tspan fill="red" dx="1">a</tspan>'
+            '<tspan fill="blue" dx="2">b</tspan></text>'
+        )
+
+        svg_utils.merge_offset_siblings(text)
+
+        assert len(text) == 2
+
+    def test_all_zero_dx_omitted(self) -> None:
+        """Merging identical spans produces no positional attribute."""
+        text = ET.fromstring("<text><tspan>a</tspan><tspan>b</tspan></text>")
+
+        svg_utils.merge_offset_siblings(text)
+
+        assert len(text) == 1
+        assert text[0].text == "ab"
+        assert "dx" not in text[0].attrib
+        assert "dy" not in text[0].attrib
+
+    def test_empty_span_with_offset_blocks_merge(self) -> None:
+        """An empty span carrying a positional attribute is ambiguous."""
+        text = ET.fromstring(
+            '<text><tspan>a</tspan><tspan dx="1" /><tspan>b</tspan></text>'
+        )
+
+        svg_utils.merge_offset_siblings(text)
+
+        # The empty span hosts no character, so the group cannot be merged.
+        assert len(text) == 3
+
+    def test_empty_span_without_offset_dropped(self) -> None:
+        """An empty span without a positional attribute is merged away."""
+        text = ET.fromstring(
+            '<text><tspan dx="1">a</tspan><tspan /><tspan>b</tspan></text>'
+        )
+
+        svg_utils.merge_offset_siblings(text)
+
+        assert len(text) == 1
+        assert text[0].text == "ab"
+        assert text[0].attrib["dx"] == "1"
+
+    def test_combining_marks_block_merge(self) -> None:
+        """Combining marks make len(text) diverge from addressable chars."""
+        text = ET.Element("text")
+        tspan1 = ET.SubElement(text, "tspan")
+        # 'e' + U+0301 COMBINING ACUTE ACCENT: two code points, one glyph.
+        tspan1.text = "e\u0301"
+        tspan2 = ET.SubElement(text, "tspan", attrib={"dx": "1"})
+        tspan2.text = "a"
+
+        svg_utils.merge_offset_siblings(text)
+
+        assert len(text) == 2
+
+    def test_no_merge_across_tail(self) -> None:
+        """A non-empty tail on a non-last member stops the run."""
+        text = ET.Element("text")
+        tspan1 = ET.SubElement(text, "tspan", attrib={"dx": "1"})
+        tspan1.text = "a"
+        tspan1.tail = " gap"
+        tspan2 = ET.SubElement(text, "tspan", attrib={"dx": "2"})
+        tspan2.text = "b"
+
+        svg_utils.merge_offset_siblings(text)
+
+        # The tail between them is real content, so they are not merged.
+        assert len(text) == 2
+        assert text[0].tail == " gap"
+
+    def test_recursive_processing(self) -> None:
+        """Nested children are processed recursively."""
+        text = ET.fromstring(
+            '<text><tspan x="1" dy="2"><tspan>L</tspan>'
+            '<tspan dx="-1">o</tspan></tspan></text>'
+        )
+
+        svg_utils.merge_offset_siblings(text)
+
+        paragraph = text[0]
+        assert len(paragraph) == 1
+        assert paragraph[0].text == "Lo"
+        assert paragraph[0].attrib["dx"] == "0 -1"
+        # The paragraph wrapper's own position is untouched.
+        assert paragraph.attrib["x"] == "1"
+        assert paragraph.attrib["dy"] == "2"
+
+
 class TestMergeSingletonChildren:
     """Tests for merge_singleton_children utility function."""
 

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -418,11 +418,13 @@ def test_text_style_kerning() -> None:
         f"Expected kerning to merge into a single tspan, got {len(tspans_with_dx)}"
     )
 
-    # The dx list carries one value per character of the merged text.
+    # The dx list has at most one value per character of the merged text.
+    # It may be shorter because trailing zero offsets are trimmed (dx defaults
+    # to 0 for characters past the end of the list).
     tspan = tspans_with_dx[0]
     dx_values = [float(value) for value in tspan.attrib["dx"].split()]
-    assert len(dx_values) == len(tspan.text or ""), (
-        "dx list length should match the number of merged characters"
+    assert 0 < len(dx_values) <= len(tspan.text or ""), (
+        "dx list should carry no more values than there are merged characters"
     )
 
     # The second paragraph has 8 characters with non-zero (tighter) kerning;

--- a/tests/test_text.py
+++ b/tests/test_text.py
@@ -404,23 +404,35 @@ def test_text_style_tracking() -> None:
 
 
 def test_text_style_kerning() -> None:
-    """Test kerning using dx attributes."""
+    """Test kerning using dx attributes.
+
+    Consecutive per-character tspans that differ only in their kerning are
+    merged into a single tspan whose ``dx`` attribute is a space-separated
+    per-character offset list (see merge_offset_siblings).
+    """
     svg = convert_psd_to_svg("texts/style-kerning-manual.psd")
 
-    # Find all tspan elements with dx attributes (kerning applied)
+    # Kerning collapses into a per-character dx list on the paragraph tspan.
     tspans_with_dx = svg.findall(".//tspan[@dx]")
-
-    # Second paragraph has 8 characters with non-zero kerning
-    # Expected characters with kerning: 'o', 'r', 'e', 'm', 'p', 's', 'u', 'm'
-    assert len(tspans_with_dx) >= 8, (
-        f"Expected at least 8 tspans with dx, got {len(tspans_with_dx)}"
+    assert len(tspans_with_dx) == 1, (
+        f"Expected kerning to merge into a single tspan, got {len(tspans_with_dx)}"
     )
 
-    # Verify dx values are negative (tighter spacing)
-    # All kerning values in the fixture are negative
-    for tspan in tspans_with_dx:
-        dx_value = float(tspan.attrib.get("dx", "0"))
-        assert dx_value < 0, f"Expected negative dx for tighter kerning, got {dx_value}"
+    # The dx list carries one value per character of the merged text.
+    tspan = tspans_with_dx[0]
+    dx_values = [float(value) for value in tspan.attrib["dx"].split()]
+    assert len(dx_values) == len(tspan.text or ""), (
+        "dx list length should match the number of merged characters"
+    )
+
+    # The second paragraph has 8 characters with non-zero (tighter) kerning;
+    # all kerning values in the fixture are negative.
+    nonzero = [value for value in dx_values if value != 0.0]
+    assert len(nonzero) >= 8, (
+        f"Expected at least 8 non-zero dx offsets, got {len(nonzero)}"
+    )
+    for value in nonzero:
+        assert value < 0, f"Expected negative dx for tighter kerning, got {value}"
 
 
 def test_text_style_tsume() -> None:


### PR DESCRIPTION
## Summary

Closes #304.

Photoshop manual kerning is emitted as a per-character `dx` offset on individual `<tspan>` elements. Because these spans share every *style* attribute but differ in `dx`, `merge_consecutive_siblings` (which only merges spans with identical attributes) left them unmerged, producing verbose output like:

```svg
<tspan x="17.49" dy="32.01">L</tspan>
<tspan dx="-0.8">o</tspan>
<tspan dx="-3.2">r</tspan>
...
```

This PR adds `merge_offset_siblings`, which consolidates runs of consecutive leaf tspans that differ **only** in positional attributes (`x`, `y`, `dx`, `dy`) into a single tspan whose positional attributes become per-character coordinate lists:

```svg
<tspan x="17.49" dy="32.01" dx="0 -0.8 -3.2 -0.8 -2.4 0 0 -3.2 -0.8 -3.2 -1.6">Lorem Ipsum</tspan>
```

The issue's example — `<tspan>a</tspan><tspan dx="0.1">b</tspan><tspan>c</tspan>` — becomes `<tspan dx="0 0.1">abc</tspan>` (the trailing `0` is trimmed because `dx` defaults to 0 past the end of the list).

## Semantics

- **Relative `dx`/`dy`**: unset positions default to `0`, internal gaps are kept as `0`, trailing zeros are trimmed.
- **Absolute `x`/`y`**: an SVG coordinate list cannot express an internal "unset / natural-advance" gap, so a group that would require one is left **unmerged** (safe fallback). A leading run of set values (e.g. `x`/`y` on the first character only) merges fine.
- A span's positional value applies to its **first** character; the remaining characters in that span stay unset.
- Groups **bail** (leave the tree untouched) on: combining marks (Mn/Mc/Me — `len(text)` would diverge from addressable characters), empty spans carrying an offset, and intervening non-empty tails. Elements with children act as group boundaries.

Wired into `_create_native_svg_text` between `merge_consecutive_siblings` and `merge_singleton_children`, in both the warp and non-warp branches.

## Verification

- Rendering is **pixel-identical** under resvg across several text fixtures (kerning, font-sizes, paragraph, tsume) — verified by rasterizing with and without the optimization.
- `ruff format`, `ruff check`, and `mypy src/ tests/` all pass.
- Full `pytest` passes (the only failures are pre-existing Playwright browser-not-installed errors, unrelated to this change).
- Added 12 unit tests for `merge_offset_siblings` and updated `test_text_style_kerning` to assert the merged per-character `dx` list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)